### PR TITLE
Fix for ACP startup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -164,7 +164,7 @@ services:
     ports:
      - 8443:8443
     volumes:
-      - ./data/seed.yaml.generated:/seed.yaml
+      - ./data/seed.yaml:/seed.yaml
       - ./data/acp_cert.pem:/acp_cert.pem
       - ./data/acp_key.pem:/acp_key.pem
     environment:


### PR DESCRIPTION
This PR corrects an ACP startup issue. Using seed.yaml.generated was causing ACP to not be able to startup

log from acp: 
```
{"error":"read /seed.yaml: is a directory","level":"fatal","msg":"failed to read yaml input","time":"2021-04-29T19:26:42Z"}
```