### PR TITLE
Migrate missing makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,44 @@ export COMPOSE_DOCKER_CLI_BUILD=1
 
 .EXPORT_ALL_VARIABLES: ;
 
+OB_APPS=developer-tpp financroo-tpp consent-page consent-self-service-portal consent-admin-portal bank
+ACP_APPS=acp crdb hazelcast
+
+.PHONY: replace-hosts
+replace-hosts:
+	./scripts/replace_hosts.sh
+
 .PHONY: build
 build:
-	docker-compose -f docker-compose.yaml build
+	docker-compose -f docker-compose.yaml -f docker-compose.build.yaml build
+
+.PHONY: run-dev
+run-dev: replace-hosts
+	docker-compose -f docker-compose.yaml -f docker-compose.build.yaml up -d
+	./scripts/wait.sh
+	make seed
+
+.PHONY: run-acp
+run-acp-apps: replace-hosts
+	docker-compose up -d --no-build ${ACP_APPS}
+	./scripts/wait.sh
+
+.PHONY: stop-acp-apps
+stop-acp-apps:
+	docker-compose rm -s -f ${ACP_APPS}
+
+.PHONY: run-apps
+run-apps:
+	docker-compose up -d --no-build ${OB_APPS}
 
 .PHONY: run
 run:
-	docker-compose -f docker-compose.yaml up -d
+	make run-acp-apps run-apps
+
+.PHONY: restart-acp
+restart-acp:
+	docker-compose rm -s -f acp
+	docker-compose up -d --no-build acp
 
 .PHONY: lint
 lint:
@@ -22,3 +53,14 @@ stop:
 .PHONY: clean
 clean:
 	docker-compose down -v
+
+.PHONY: dump
+dump:
+	docker exec acp ./acp export \
+		--sql.url 'postgres://root@crdb:26257/defaultdb?sslmode=disable' \
+		--secret.key KNEcLGdDqpwrXDubqPgDSUkMMsLPXaHh \
+		--format yaml > data/seed.yaml
+
+.PHONY: run-tests
+run-tests:
+	yarn --cwd tests run cypress open

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -1,0 +1,27 @@
+version: "3.0"
+
+services:
+  developer-tpp:
+    build:
+      context: .
+      dockerfile: apps/developer-tpp/Dockerfile
+  financroo-tpp:
+    build:
+      context: .
+      dockerfile: apps/financroo-tpp/Dockerfile
+  consent-page:
+    build:
+      context: .
+      dockerfile: consent/consent-page/Dockerfile
+  consent-self-service-portal:
+    build:
+      context: .
+      dockerfile: consent/self-service-portal/Dockerfile
+  consent-admin-portal:
+    build:
+      context: .
+      dockerfile: consent/admin-portal/Dockerfile
+  bank:
+    build:
+      context: .
+      dockerfile: apps/bank/Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,9 +22,6 @@ services:
       - KEY_FILE=/tpp_key.pem
       - ROOT_CA=/ca.pem
       - BANK_URL=http://bank:8070
-    build:
-      context: .
-      dockerfile: apps/developer-tpp/Dockerfile
 
   financroo-tpp:
     image: cloudentity/openbanking-quickstart-financroo-tpp:latest
@@ -42,9 +39,6 @@ services:
       - CERT_FILE=/certs/tpp_cert.pem
       - KEY_FILE=/certs/tpp_key.pem
       - DB_FILE=/app/data/my.db
-    build:
-      context: .
-      dockerfile: apps/financroo-tpp/Dockerfile
 
   consent-page:
     image: cloudentity/openbanking-quickstart-consent-page:latest
@@ -72,9 +66,6 @@ services:
       # - MOBILE_CLAIM=mobile_verified
       # - TWILIO_ACCOUNT_SID=
       # - TWILIO_AUTH_TOKEN=
-    build:
-      context: .
-      dockerfile: consent/consent-page/Dockerfile
 
   consent-self-service-portal:
     image: cloudentity/openbanking-quickstart-consent-self-service-portal:latest
@@ -102,9 +93,6 @@ services:
       - INTROSPECT_CLIENT_ID=bv2dkff8mll9cf6pvd6g
       - INTROSPECT_CLIENT_SECRET=KThGH68f-gMC4cscGLFeOpIU4EYriYhKspOV9IwHbnw
       - INTROSPECT_ISSUER_URL=${ACP_INTERNAL_URL}/default/bank-customers
-    build:
-      context: .
-      dockerfile: consent/self-service-portal/Dockerfile
 
   consent-admin-portal:
     image: cloudentity/openbanking-quickstart-consent-admin-portal:latest
@@ -132,9 +120,6 @@ services:
       - INTROSPECT_CLIENT_ID=bv2fddlpfc67lmeti32g
       - INTROSPECT_CLIENT_SECRET=RkAIOVRlP6ZLhDvYixT1wBb8DG3bVkXAouoIrX7cwzA
       - INTROSPECT_ISSUER_URL=${ACP_INTERNAL_URL}/default/bank-admins
-    build:
-      context: .
-      dockerfile: consent/admin-portal/Dockerfile
       
   bank:
     image: cloudentity/openbanking-quickstart-bank:latest
@@ -153,9 +138,6 @@ services:
       - CERT_FILE=/bank_cert.pem
       - KEY_FILE=/bank_key.pem
       - ROOT_CA=/ca.pem
-    build:
-      context: .
-      dockerfile: apps/bank/Dockerfile
 
   acp:
     container_name: acp


### PR DESCRIPTION
- migrate missing make targets
- split docker-compose into two files to be able to build images (local development) and pull images (sales demos)