### PR TITLE
Configurable consent page import credentials

### DIFF
--- a/data/imports/openbanking.tmpl
+++ b/data/imports/openbanking.tmpl
@@ -35,7 +35,7 @@ idps:
           name: user3
 server_consents:
 - tenant_id: default
-  client_id: {{ default "bv0ocudfotn6edhsiu7" .consent_page_client_id }}
+  client_id: {{ default "bv0ocudfotn6edhsiu7g" .consent_page_client_id }}
   custom:
     server_consent_url: {{ .consent_page_url }}
   server_id: openbanking
@@ -44,7 +44,7 @@ clients:
 # consent page
 - tenant_id: default
   authorization_server_id: system
-  client_id: {{ default "bv0ocudfotn6edhsiu7" .consent_page_client_id }}
+  client_id: {{ default "bv0ocudfotn6edhsiu7g" .consent_page_client_id }}
   client_secret: {{ default "pMPBmv62z3Jt1S4sWl2qRhOhEGPVZ9EcujGL7Xy0-E0" .consent_page_client_secret }}
   client_name: custom server consent
   grant_types:

--- a/data/imports/openbanking.tmpl
+++ b/data/imports/openbanking.tmpl
@@ -35,11 +35,7 @@ idps:
           name: user3
 server_consents:
 - tenant_id: default
-  {{ if .consent_page_client_id }}
-  client_id: {{ .consent_page_client_id }}
-  {{ else }}
-  client_id: bv0ocudfotn6edhsiu7g
-  {{ end }}
+  client_id: {{ default "bv0ocudfotn6edhsiu7" .consent_page_client_id }}
   custom:
     server_consent_url: {{ .consent_page_url }}
   server_id: openbanking
@@ -48,16 +44,8 @@ clients:
 # consent page
 - tenant_id: default
   authorization_server_id: system
-  {{ if .consent_page_client_id }}
-  client_id: {{ .consent_page_client_id }}
-  {{ else }}
-  client_id: bv0ocudfotn6edhsiu7g
-  {{ end }}
-  {{ if .consent_page_client_secret }}
-  client_secret: {{ if .consent_page_client_secret }}
-  {{ else }}
-  client_secret: pMPBmv62z3Jt1S4sWl2qRhOhEGPVZ9EcujGL7Xy0-E0
-  {{ end }}
+  client_id: {{ default "bv0ocudfotn6edhsiu7" .consent_page_client_id }}
+  client_secret: {{ default "pMPBmv62z3Jt1S4sWl2qRhOhEGPVZ9EcujGL7Xy0-E0" .consent_page_client_secret }}
   client_name: custom server consent
   grant_types:
   - client_credentials

--- a/data/imports/openbanking.tmpl
+++ b/data/imports/openbanking.tmpl
@@ -34,19 +34,31 @@ idps:
         authentication_context:
           name: user3
 server_consents:
-- client_id: bv0ocudfotn6edhsiu7g
+- tenant_id: default
+  {{ if .consent_page_client_id }}
+  client_id: {{ .consent_page_client_id }}
+  {{ else }}
+  client_id: bv0ocudfotn6edhsiu7g
+  {{ end }}
   custom:
     server_consent_url: {{ .consent_page_url }}
   server_id: openbanking
-  tenant_id: default
   type: custom
 clients:
 # consent page
 - tenant_id: default
   authorization_server_id: system
+  {{ if .consent_page_client_id }}
+  client_id: {{ .consent_page_client_id }}
+  {{ else }}
   client_id: bv0ocudfotn6edhsiu7g
-  client_name: custom server consent
+  {{ end }}
+  {{ if .consent_page_client_secret }}
+  client_secret: {{ if .consent_page_client_secret }}
+  {{ else }}
   client_secret: pMPBmv62z3Jt1S4sWl2qRhOhEGPVZ9EcujGL7Xy0-E0
+  {{ end }}
+  client_name: custom server consent
   grant_types:
   - client_credentials
   scopes:

--- a/data/variables.yaml
+++ b/data/variables.yaml
@@ -7,3 +7,5 @@ financroo_tls_client_auth_subject_dn: CN=cid1.authorization.cloudentity.com,OU=A
 bank_tls_client_auth_subject_dn: CN=cid2.authorization.cloudentity.com,OU=Authorization,O=Cloudentity,L=Seattle,ST=Washinghton,C=US
 financroo_pem_file: /certs/tpp_cert.pem
 ca_pem_file: /certs/ca.pem
+consent_page_client_id: bv0ocudfotn6edhsiu7
+consent_page_client_secret: MPBmv62z3Jt1S4sWl2qRhOhEGPVZ9EcujGL7Xy0-E0

--- a/data/variables.yaml
+++ b/data/variables.yaml
@@ -8,4 +8,4 @@ bank_tls_client_auth_subject_dn: CN=cid2.authorization.cloudentity.com,OU=Author
 financroo_pem_file: /certs/tpp_cert.pem
 ca_pem_file: /certs/ca.pem
 consent_page_client_id: bv0ocudfotn6edhsiu7
-consent_page_client_secret: MPBmv62z3Jt1S4sWl2qRhOhEGPVZ9EcujGL7Xy0-E0
+consent_page_client_secret: pMPBmv62z3Jt1S4sWl2qRhOhEGPVZ9EcujGL7Xy0-E0

--- a/data/variables.yaml
+++ b/data/variables.yaml
@@ -7,5 +7,5 @@ financroo_tls_client_auth_subject_dn: CN=cid1.authorization.cloudentity.com,OU=A
 bank_tls_client_auth_subject_dn: CN=cid2.authorization.cloudentity.com,OU=Authorization,O=Cloudentity,L=Seattle,ST=Washinghton,C=US
 financroo_pem_file: /certs/tpp_cert.pem
 ca_pem_file: /certs/ca.pem
-consent_page_client_id: bv0ocudfotn6edhsiu7
+consent_page_client_id: bv0ocudfotn6edhsiu7g
 consent_page_client_secret: pMPBmv62z3Jt1S4sWl2qRhOhEGPVZ9EcujGL7Xy0-E0


### PR DESCRIPTION
If necessary it's now possible to override consent page client id and secret