### PR TITLE
[AUT-4151]: Allow Quickstart to Run Beside ACP Repo

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -178,7 +178,7 @@ services:
       - FEATURES_OPENBANKING_BRASIL_CONSENTS=true
       - FEATURES_OPENBANKING_BRASIL_PAYMENTS=true
       - FEATURES_DEV_MODE=true
-      - SERVER_MTLS_URL=https://test-docker:8444
+      - SERVER_MTLS_URL=https://test-docker:8443
       - SERVER_URL=${ACP_URL}
       - LOGGING_LEVEL=debug
       - SERVER_HTTP_LOGS=true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -156,7 +156,7 @@ services:
       - SPEC=${SPEC}
 
   acp:
-    container_name: acp
+    container_name: quickstart-acp
     restart: always
     image: ${ACP_DOCKER_IMAGE}:${ACP_VERSION}
     networks:
@@ -178,7 +178,7 @@ services:
       - FEATURES_OPENBANKING_BRASIL_CONSENTS=true
       - FEATURES_OPENBANKING_BRASIL_PAYMENTS=true
       - FEATURES_DEV_MODE=true
-      - SERVER_MTLS_URL=https://test-docker:8443
+      - SERVER_MTLS_URL=https://test-docker:8444
       - SERVER_URL=${ACP_URL}
       - LOGGING_LEVEL=debug
       - SERVER_HTTP_LOGS=true
@@ -200,12 +200,12 @@ services:
       - --create-default-tenant
 
   crdb:
-    container_name: crdb
+    container_name: quickstart-crdb
     image: cockroachdb/cockroach:v20.2.6
     restart: always
     ports:
-      - 26257:26257
-      - 8081:8080
+      - 26258:26257
+      - 8082:8080
     command: start-single-node --insecure
     volumes:
       - crdb:/cockroach/cockroach-data"


### PR DESCRIPTION
## Jira task - [AUT-4151](https://cloudentity.atlassian.net/browse/AUT-4151)

## Description
This PR changes the docker-compose file to allow one to run quickstart alongside of the ACP repo `make prepare` without having to take down services due to conflicting names.

## Type of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [X] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)

## Implementation details
