### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,7 @@ To run tests:
 - `git add . && git commit -m 'Release VERSION' && git push`
 - verify if github action build and pushed released images to public docker hub
 - `git tag -a VERSION && git push --tags`
+
+## FAQ
+### I've deployed my quickstart apps under a domain that's not "localhost", but after I run the configuration job, the client application redirect urls are all still localhost.
+-  Under `data/variables/yaml` edit the values for `consent_self_service_portal_url`, ` consent_admin_portal_url`, `consent_page_url`, `developer_tpp_url`, and `financroo_tpp_url`.


### PR DESCRIPTION
## Description
Last week, Symcor ran into an issue where after the quickstart configuration importer ran, they had to manually change all the client redirect urls because they were set to localhost (they had deployed the quickstart applications elsewhere). 

I initially thought we didn't have a templated way of setting those values for the config importer, but later I discovered that we actually did. I have updated the readme to include this information because it is not readily apparent how to accomplish this. 

## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [X] Other (if none of the other choices apply)
