### PR TITLE
AUT-5067 Fix docker-compose.yaml where env vars were hardwired.

### DIFF
--- a/apps/custom-idp/.env
+++ b/apps/custom-idp/.env
@@ -7,7 +7,7 @@ CLIENT_SECRET	= h8udwSBfgfGkwUkHVsrlQjPAKDM9Ng6w995HPh_j1BY
 ISSUER_URL	= https://host.docker.internal:8443/default/system
 
 # The CA cert is optional, unless ACP uses a self-signed cert.
-ROOT_CA		= /certs/ca.pem
+ROOT_CA		= "" # /certs/ca.pem
 CERT_FILE	= /certs/bank_cert.pem
 KEY_FILE	= /certs/bank_key.pem
 PUBLISH		= 8080
@@ -19,4 +19,4 @@ OIDC_ISSUER_URL		= https://host.docker.internal:8443/default/external-authorizer
 OIDC_REDIRECT_URL	= https://host.docker.internal:8080/callback
 
 # The CA cert is optional, unless the OIDC server uses a self-signed cert.
-OIDC_CA_PATH		= /certs/ca.pem
+OIDC_CA_PATH		= "" # /certs/ca.pem

--- a/apps/custom-idp/docker-compose.yaml
+++ b/apps/custom-idp/docker-compose.yaml
@@ -18,9 +18,9 @@ services:
       - CLIENT_ID=${CLIENT_ID}
       - CLIENT_SECRET=${CLIENT_SECRET}
       - ISSUER_URL=${ISSUER_URL}
-      - CERT_FILE=/certs/acp_cert.pem
-      - KEY_FILE=/certs/acp_key.pem
-      - ROOT_CA=/certs/ca.pem
+      - CERT_FILE=${CERT_FILE}
+      - KEY_FILE=${KEY_FILE}
+      - ROOT_CA=${ROOT_CA}
       - LOG_LEVEL=info
       - GIN_MODE=debug
       - OIDC_CLIENT_ID=${OIDC_CLIENT_ID}


### PR DESCRIPTION
## Jira task - [AUT-5067] https://cloudentity.atlassian.net/browse/AUT-5067

## Description

A few docker-compose.yaml env vars were hardwired, instead of referring to the .env file values.

## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)



[AUT-5067]: https://cloudentity.atlassian.net/browse/AUT-5067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ