### PR TITLE
Set correct audience on cdr service

### DIFF
--- a/.env
+++ b/.env
@@ -14,7 +14,7 @@ ACP_BASE_URL=authorization.cloudentity.com:8443
 ACP_MTLS_URL=https://authorization.cloudentity.com:8443
 
 # acp version
-ACP_VERSION=c4c9f8d
+ACP_VERSION=06ef40d
 
 # acp docker image
 ACP_DOCKER_IMAGE=docker.cloudentity.io/acp

--- a/.env-local
+++ b/.env-local
@@ -14,7 +14,7 @@ ACP_BASE_URL=authorization.cloudentity.com:8443
 ACP_MTLS_URL=https://authorization.cloudentity.com:8443
 
 # acp version
-ACP_VERSION=c4c9f8d
+ACP_VERSION=06ef40d
 
 # acp docker image
 ACP_DOCKER_IMAGE=docker.cloudentity.io/acp

--- a/data/imports-cdr/cdr.tmpl
+++ b/data/imports-cdr/cdr.tmpl
@@ -110,3 +110,13 @@ claims:
   source_type: client
   tenant_id: {{ .tenant_id }}
   type: access_token
+
+services:
+- id: cdr-cdr-australia
+  tenant_id: {{ .tenant_id }}
+  authorization_server_id: cdr
+  name: CDR Australia
+  custom_audience: cds-au
+  description: ''
+  system: true
+  with_specification: false

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -290,14 +290,14 @@ services:
       - crdb:/cockroach/cockroach-data"
 
   redis:
-    container_name: redis
+    container_name: quickstart-redis
     image: redis:6.2.6
     restart: on-failure
     command: redis-server /usr/local/etc/redis/redis.conf
     volumes:
       - ./mount/redis/redis.conf:/usr/local/etc/redis/redis.conf
     ports:
-      - 6379:6379
+      - 6380:6379
 
   configuration:
     container_name: configuration


### PR DESCRIPTION
## Description

<!--- Describe what this feature does
  REQUIRED
  USED IN RELEASE NOTES
-->

Set correct audience on CDR service and rename Redis docker to allow calling `make prepare` on ACP and running quickstart at the same time 

## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)

## Implementation details

<!--- Describe implementation details if needed -->

## Screenshots (if appropriate):
