### PR TITLE
Open Banking Brasil Consent Self Service

### DIFF
--- a/consent/self-service-portal/handler.go
+++ b/consent/self-service-portal/handler.go
@@ -129,19 +129,18 @@ func (s *Server) ListConsents() func(*gin.Context) {
 			return
 		}
 
-		for _, spec := range []Spec{OBUK, CDR} {
+		for _, spec := range SupportedSpecs {
 			if acc, err = s.BankClients[spec].GetInternalAccounts(sub); err != nil {
 				Error(c, ToAPIError(err))
 				return
 			}
 
-			accounts.Accounts = append(accounts.Accounts, acc.Accounts...)
-
-			if cc, err = s.ConsentClients[spec].FetchConsents(c, accounts.GetAccountIDs()); err != nil {
+			if cc, err = s.ConsentClients[spec].FetchConsents(c, acc.GetAccountIDs()); err != nil {
 				Error(c, ToAPIError(err))
 				return
 			}
 
+			accounts.Accounts = append(accounts.Accounts, acc.Accounts...)
 			clientsAndConsents = append(clientsAndConsents, cc...)
 		}
 
@@ -256,6 +255,8 @@ func (s *Server) GetConsentClientByConsentType(consentType string) ConsentClient
 	switch consentType {
 	case "account_access", "domestic_payment":
 		return s.ConsentClients[OBUK]
+	case "consents":
+		return s.ConsentClients[OBBR]
 	case "cdr_arrangement":
 		return s.ConsentClients[CDR]
 	}
@@ -266,6 +267,8 @@ func (s *Server) GetBankClientByConsentType(consentType string) BankClient {
 	switch consentType {
 	case "account_access", "domestic_payment":
 		return s.BankClients[OBUK]
+	case "consents":
+		return s.BankClients[OBBR]
 	case "cdr_arrangement":
 		return s.BankClients[CDR]
 	}

--- a/consent/self-service-portal/main.go
+++ b/consent/self-service-portal/main.go
@@ -19,7 +19,12 @@ type Spec string
 const (
 	OBUK Spec = "obuk"
 	CDR  Spec = "cdr"
+	OBBR Spec = "obbr"
 )
+
+var SupportedSpecs = []Spec{
+	OBUK, CDR, OBBR,
+}
 
 type Config struct {
 	SystemClientID              string        `env:"SYSTEM_CLIENT_ID,required"`
@@ -27,11 +32,13 @@ type Config struct {
 	SystemIssuerURL             *url.URL      `env:"SYSTEM_ISSUER_URL,required"`
 	OpenbankingUKWorkspaceID    string        `env:"OPENBANKING_UK_WORKSPACE_ID,required"`
 	CDRWorkspaceID              string        `env:"CDR_WORKSPACE_ID,required"`
+	OpenbankingBRWorkspaceID    string        `env:"OPENBANKING_BR_WORKSPACE_ID,required"`
 	Timeout                     time.Duration `env:"TIMEOUT" envDefault:"5s"`
 	RootCA                      string        `env:"ROOT_CA"`
 	CertFile                    string        `env:"CERT_FILE,required"`
 	KeyFile                     string        `env:"KEY_FILE,required"`
-	BankURL                     *url.URL      `env:"BANK_URL,required"`
+	UKBankURL                   *url.URL      `env:"UK_BANK_URL,required"`
+	BrasilBankURL               *url.URL      `env:"BRASIL_BANK_URL,required"`
 	Port                        int           `env:"PORT" envDefault:"8085"`
 	LoginAuthorizationServerURL string        `env:"LOGIN_AUTHORIZATION_SERVER_URL,required"`
 	LoginClientID               string        `env:"LOGIN_CLIENT_ID,required"`
@@ -105,11 +112,13 @@ func NewServer() (Server, error) {
 	server.BankClients = map[Spec]BankClient{
 		OBUK: NewOBUKBankClient(server.Config),
 		CDR:  &CDRBankClient{},
+		OBBR: NewOBBRBankClient(server.Config),
 	}
 
 	server.ConsentClients = map[Spec]ConsentClient{
 		OBUK: NewOBUKConsentImpl(&server),
 		CDR:  NewCDRArrangementImpl(&server),
+		OBBR: NewOBBRConsentImpl(&server),
 	}
 
 	return server, nil

--- a/consent/self-service-portal/obbr_bank_client.go
+++ b/consent/self-service-portal/obbr_bank_client.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/cloudentity/openbanking-quickstart/openbanking/obbr/accounts/models"
+)
+
+type OBBRBankClient struct {
+	baseURL string
+	*http.Client
+}
+
+func NewOBBRBankClient(config Config) BankClient {
+	c := OBBRBankClient{}
+
+	c.Client = &http.Client{}
+	c.baseURL = config.BrasilBankURL.String()
+
+	return &c
+}
+
+func (c *OBBRBankClient) GetInternalAccounts(subject string) (InternalAccounts, error) {
+	var (
+		request  *http.Request
+		response *http.Response
+		bytes    []byte
+		resp     = models.ResponseAccountList{}
+		err      error
+	)
+
+	if request, err = http.NewRequest("GET", fmt.Sprintf("%s/internal/accounts?id=%s", c.baseURL, subject), nil); err != nil {
+		return InternalAccounts{}, err
+	}
+
+	if response, err = c.Client.Do(request); err != nil {
+		return InternalAccounts{}, err
+	}
+	defer response.Body.Close()
+
+	if bytes, err = ioutil.ReadAll(response.Body); err != nil {
+		return InternalAccounts{}, err
+	}
+
+	if response.StatusCode != 200 {
+		return InternalAccounts{}, fmt.Errorf("unexpected status code: %d, body: %s", response.StatusCode, string(bytes))
+	}
+
+	if err = json.Unmarshal(bytes, &resp); err != nil {
+		return InternalAccounts{}, nil
+	}
+
+	return c.ToInternalAccounts(resp), nil
+}
+
+func (c *OBBRBankClient) ToInternalAccounts(data models.ResponseAccountList) InternalAccounts {
+	accounts := make([]InternalAccount, len(data.Data))
+	for i, account := range data.Data {
+		accounts[i] = InternalAccount{
+			ID:   string(*account.AccountID),
+			Name: string(*account.Number),
+		}
+	}
+	return InternalAccounts{Accounts: accounts}
+}

--- a/consent/self-service-portal/obbr_bank_client.go
+++ b/consent/self-service-portal/obbr_bank_client.go
@@ -60,8 +60,8 @@ func (c *OBBRBankClient) ToInternalAccounts(data models.ResponseAccountList) Int
 	accounts := make([]InternalAccount, len(data.Data))
 	for i, account := range data.Data {
 		accounts[i] = InternalAccount{
-			ID:   string(*account.AccountID),
-			Name: string(*account.Number),
+			ID:   *account.AccountID,
+			Name: *account.Number,
 		}
 	}
 	return InternalAccounts{Accounts: accounts}

--- a/consent/self-service-portal/obbr_consent_impl.go
+++ b/consent/self-service-portal/obbr_consent_impl.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/go-openapi/strfmt"
+
+	obbrModels "github.com/cloudentity/acp-client-go/clients/openbanking/client/openbanking_b_r"
+	obModels "github.com/cloudentity/acp-client-go/clients/openbanking/models"
+)
+
+type OBBRConsentImpl struct {
+	*Server
+}
+
+func NewOBBRConsentImpl(s *Server) ConsentClient {
+	return &OBBRConsentImpl{s}
+}
+
+func (o *OBBRConsentImpl) FetchConsents(c *gin.Context, accountIDs []string) ([]ClientConsents, error) {
+	var (
+		response *obbrModels.ListOBBRConsentsOK
+		err      error
+		types    []string
+		cac      []ClientConsents
+		ok       bool
+	)
+
+	if types, ok = c.GetQueryArray("types"); !ok {
+		types = nil
+	}
+
+	if response, err = o.Client.Openbanking.Openbankingbr.ListOBBRConsents(
+		obbrModels.NewListOBBRConsentsParamsWithContext(c).
+			WithWid(o.Config.OpenbankingBRWorkspaceID).
+			WithConsentsRequest(&obModels.OBBRConsentsRequest{
+				Types:    types,
+				Accounts: accountIDs,
+			}),
+		nil,
+	); err != nil {
+		return cac, err
+	}
+
+	return MapClientsToConsents(o.getClients(response), o.getConsents(response)), nil
+}
+
+func (o *OBBRConsentImpl) getClients(resp *obbrModels.ListOBBRConsentsOK) []Client {
+	var clients Clients
+
+	for _, consent := range resp.Payload.Consents {
+		if consent.Client != nil {
+			clients = append(clients, Client{
+				ID:        consent.Client.ID,
+				Name:      consent.Client.Name,
+				LogoURI:   consent.Client.LogoURI,
+				ClientURI: consent.Client.ClientURI,
+			})
+		}
+	}
+
+	return clients.Unique()
+}
+
+func (o *OBBRConsentImpl) getConsents(resp *obbrModels.ListOBBRConsentsOK) []Consent {
+	var consents []Consent
+
+	for _, consent := range resp.Payload.Consents {
+		var (
+			expiresAt   strfmt.DateTime
+			updatedAt   strfmt.DateTime
+			permissions []string
+		)
+
+		c := Consent{
+			AccountIDs:  consent.AccountIds,
+			ConsentID:   consent.ConsentID,
+			TenantID:    consent.TenantID,
+			ServerID:    consent.ServerID,
+			ClientID:    consent.ClientID,
+			Status:      consent.Status,
+			Type:        string(consent.Type),
+			CreatedAt:   consent.CreatedAt,
+			ExpiresAt:   expiresAt,
+			UpdatedAt:   updatedAt,
+			Permissions: permissions,
+		}
+
+		switch consent.Type {
+		case "consents":
+			c.ExpiresAt = consent.CustomerDataAccessConsent.ExpirationDateTime
+			c.UpdatedAt = strfmt.DateTime(consent.CustomerDataAccessConsent.StatusUpdateDateTime)
+			c.Permissions = obbrPermissionsToStringSlice(consent.CustomerDataAccessConsent.Permissions)
+		case "payments":
+			// TODO: payments aren't implemented yet
+			/*c.UpdatedAt = consent.DomesticPaymentConsent.StatusUpdateDateTime
+			c.DebtorAccountIdentification = string(*consent.DomesticPaymentConsent.Initiation.DebtorAccount.Identification)
+			c.DebtorAccountName = consent.DomesticPaymentConsent.Initiation.DebtorAccount.Name
+			c.CreditorAccountIdentification = string(*consent.DomesticPaymentConsent.Initiation.CreditorAccount.Identification)
+			c.CreditorAccountName = consent.DomesticPaymentConsent.Initiation.CreditorAccount.Name
+			c.Currency = string(*consent.DomesticPaymentConsent.Initiation.InstructedAmount.Currency)
+			c.Amount = string(*consent.DomesticPaymentConsent.Initiation.InstructedAmount.Amount)
+			c.CompletionDateTime = consent.DomesticPaymentConsent.Authorisation.CompletionDateTime*/
+		}
+
+		consents = append(consents, c)
+	}
+
+	return consents
+}
+
+func obbrPermissionsToStringSlice(permissions []obModels.OpenbankingBrasilConsentPermission1) []string {
+	ret := make([]string, len(permissions))
+	for idx, perm := range permissions {
+		ret[idx] = string(perm)
+	}
+	return ret
+}
+
+func (o *OBBRConsentImpl) RevokeConsent(c *gin.Context, consentID string) (err error) {
+	if _, err = o.Client.Openbanking.Openbankingbr.RevokeOBBRConsent(
+		obbrModels.NewRevokeOBBRConsentParamsWithContext(c).
+			WithWid(o.Config.OpenbankingBRWorkspaceID).
+			WithConsentID(consentID),
+		nil,
+	); err != nil {
+		return err
+	}
+	return nil
+}

--- a/consent/self-service-portal/obbr_consent_impl.go
+++ b/consent/self-service-portal/obbr_consent_impl.go
@@ -88,18 +88,10 @@ func (o *OBBRConsentImpl) getConsents(resp *obbrModels.ListOBBRConsentsOK) []Con
 		switch consent.Type {
 		case "consents":
 			c.ExpiresAt = consent.CustomerDataAccessConsent.ExpirationDateTime
-			c.UpdatedAt = strfmt.DateTime(consent.CustomerDataAccessConsent.StatusUpdateDateTime)
+			c.UpdatedAt = consent.CustomerDataAccessConsent.StatusUpdateDateTime
 			c.Permissions = obbrPermissionsToStringSlice(consent.CustomerDataAccessConsent.Permissions)
 		case "payments":
-			// TODO: payments aren't implemented yet
-			/*c.UpdatedAt = consent.DomesticPaymentConsent.StatusUpdateDateTime
-			c.DebtorAccountIdentification = string(*consent.DomesticPaymentConsent.Initiation.DebtorAccount.Identification)
-			c.DebtorAccountName = consent.DomesticPaymentConsent.Initiation.DebtorAccount.Name
-			c.CreditorAccountIdentification = string(*consent.DomesticPaymentConsent.Initiation.CreditorAccount.Identification)
-			c.CreditorAccountName = consent.DomesticPaymentConsent.Initiation.CreditorAccount.Name
-			c.Currency = string(*consent.DomesticPaymentConsent.Initiation.InstructedAmount.Currency)
-			c.Amount = string(*consent.DomesticPaymentConsent.Initiation.InstructedAmount.Amount)
-			c.CompletionDateTime = consent.DomesticPaymentConsent.Authorisation.CompletionDateTime*/
+			// TODO:
 		}
 
 		consents = append(consents, c)

--- a/consent/self-service-portal/obuk_bank_client.go
+++ b/consent/self-service-portal/obuk_bank_client.go
@@ -18,7 +18,7 @@ func NewOBUKBankClient(config Config) BankClient {
 	c := OBUKBankClient{}
 
 	c.Client = &http.Client{}
-	c.baseURL = config.BankURL.String()
+	c.baseURL = config.UKBankURL.String()
 
 	return &c
 }
@@ -53,10 +53,10 @@ func (c *OBUKBankClient) GetInternalAccounts(subject string) (InternalAccounts, 
 		return InternalAccounts{}, nil
 	}
 
-	return ToInternalAccounts(resp), nil
+	return c.ToInternalAccounts(resp), nil
 }
 
-func ToInternalAccounts(data models.OBReadAccount6) InternalAccounts {
+func (c *OBUKBankClient) ToInternalAccounts(data models.OBReadAccount6) InternalAccounts {
 	accounts := make([]InternalAccount, len(data.Data.Account))
 	for i, account := range data.Data.Account {
 		accounts[i] = InternalAccount{

--- a/consent/self-service-portal/web/app/src/components/ApplicationSimpleCard.tsx
+++ b/consent/self-service-portal/web/app/src/components/ApplicationSimpleCard.tsx
@@ -106,6 +106,7 @@ function ApplicationSimpleCard({ client, clickable = true }) {
         (v) =>
           (v.type === "account_access" && "Accounts") ||
           (v.type === "domestic_payment" && "Payments") ||
+          (v.type === "consents" && "Accounts") ||
           (v.type === "cdr_arrangement" && "Accounts") ||
           null 
       )

--- a/consent/self-service-portal/web/app/src/components/Dashboard.tsx
+++ b/consent/self-service-portal/web/app/src/components/Dashboard.tsx
@@ -51,7 +51,7 @@ export default function Dashboard({
   const filteredClientConsents =
     (filter === "account" &&
       clientConsents.filter((v) =>
-        v.consents.every((c) => c.type === "account_access" || c.type == "cdr_arrangement")
+        v.consents.every((c) => c.type === "account_access" || c.type == "cdr_arrangement" || c.type == "consents")
       )) ||
     (filter === "payment" &&
       clientConsents.filter((v) =>

--- a/consent/self-service-portal/web/app/src/components/applicationDetails/ApplicationAccessTabs.tsx
+++ b/consent/self-service-portal/web/app/src/components/applicationDetails/ApplicationAccessTabs.tsx
@@ -76,7 +76,7 @@ function ApplicationAccessTabs({
       <div>
         {tab === "account" && (
           <ApplicationAccessTable
-            data={data.consents.filter((v) => v.type === "account_access" || v.type == "cdr_arrangement")}
+            data={data.consents.filter((v) => v.type === "account_access" || v.type == "cdr_arrangement" || v.type == "consents")}
             type="account"
             handleRevoke={handleRevoke}
             accounts={accounts}

--- a/consent/self-service-portal/web/app/src/components/applicationDetails/utils.tsx
+++ b/consent/self-service-portal/web/app/src/components/applicationDetails/utils.tsx
@@ -88,6 +88,128 @@ export const permissionsDict = {
     Language:
       "The full legal name(s) of account holder(s). Address(es), telephone number(s) and email address(es)*",
   },
+
+  CREDIT_CARDS_ACCOUNTS_BILLS_TRANSACTIONS_READ: {
+    Cluster: "TODO", 
+    Language: "TODO",
+  },
+                    UNARRANGED_ACCOUNTS_OVERDRAFT_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    ACCOUNTS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    LOANS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    LOANS_SCHEDULED_INSTALMENTS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    FINANCINGS_SCHEDULED_INSTALMENTS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    UNARRANGED_ACCOUNTS_OVERDRAFT_WARRANTIES_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    UNARRANGED_ACCOUNTS_OVERDRAFT_PAYMENTS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    INVOICE_FINANCINGS_WARRANTIES_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    CUSTOMERS_PERSONAL_IDENTIFICATIONS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    CREDIT_CARDS_ACCOUNTS_LIMITS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    FINANCINGS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    INVOICE_FINANCINGS_PAYMENTS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    RESOURCES_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    ACCOUNTS_BALANCES_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    ACCOUNTS_OVERDRAFT_LIMITS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    LOANS_WARRANTIES_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    UNARRANGED_ACCOUNTS_OVERDRAFT_SCHEDULED_INSTALMENTS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    CREDIT_CARDS_ACCOUNTS_BILLS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    INVOICE_FINANCINGS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    CUSTOMERS_PERSONAL_ADITTIONALINFO_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    FINANCINGS_WARRANTIES_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    INVOICE_FINANCINGS_SCHEDULED_INSTALMENTS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    CUSTOMERS_BUSINESS_IDENTIFICATIONS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    CREDIT_CARDS_ACCOUNTS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    CREDIT_CARDS_ACCOUNTS_TRANSACTIONS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    LOANS_PAYMENTS_READ:{
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    CUSTOMERS_BUSINESS_ADITTIONALINFO_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    ACCOUNTS_TRANSACTIONS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+                    FINANCINGS_PAYMENTS_READ: {
+                      Cluster: "TODO", 
+                      Language: "TODO",
+                    },
+
 };
 
 export const currencyDict = {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -208,11 +208,13 @@ services:
       - SYSTEM_CLIENT_SECRET=PBV7q0akoP603rZbU0EFdxbhZ-djxF7FIVwyKaLnBYU
       - SYSTEM_ISSUER_URL=${ACP_MTLS_URL}/${TENANT}/system
       - OPENBANKING_UK_WORKSPACE_ID=openbanking
+      - OPENBANKING_BR_WORKSPACE_ID=openbanking_brasil
       - CDR_WORKSPACE_ID=cdr
       - CERT_FILE=/bank_cert.pem
       - KEY_FILE=/bank_key.pem
       - ROOT_CA=/ca.pem
-      - BANK_URL=${BANK_URL}
+      - UK_BANK_URL=http://bank-uk:8070
+      - BRASIL_BANK_URL=http://bank-br:8070
       - LOGIN_AUTHORIZATION_SERVER_URL=${ACP_URL}
       - LOGIN_AUTHORIZATION_SERVER_ID=bank-customers
       - LOGIN_TENANT_ID=${TENANT}

--- a/tests/cypress/integration/obbr/ConsentSelfServiceTests.ts
+++ b/tests/cypress/integration/obbr/ConsentSelfServiceTests.ts
@@ -1,0 +1,78 @@
+import {AcpLoginPage} from '../../pages/acp/AcpLoginPage';
+import {ConsentPage} from '../../pages/consent/ConsentPage';
+import {ErrorPage} from '../../pages/ErrorPage';
+import {Credentials} from "../../pages/Credentials";
+import {ConsentSelfServicePage} from '../../pages/consent-self-service/ConsentSelfServicePage';
+import {Urls} from "../../pages/Urls";
+import {MfaPage} from "../../pages/mfa/MfaPage";
+import {FinancrooLoginPage} from "../../pages/financroo/FinancrooLoginPage";
+import {FinancrooWelcomePage} from "../../pages/financroo/FinancrooWelcomePage";
+import {FinancrooAccountsPage} from "../../pages/financroo/accounts/FinancrooAccountsPage";
+import {FinancrooInvestmentsPage} from "../../pages/financroo/investments/FinancrooInvestmentsPage";
+import {FinancrooContributePage} from "../../pages/financroo/investments/FinancrooContributePage";
+import {ConsentSelfServiceApplicationPage} from "../../pages/consent-self-service/ConsentSelfServiceApplicationPage";
+import {EnvironmentVariables} from "../../pages/EnvironmentVariables"
+import { FinancrooModalPage } from '../../pages/financroo/accounts/FinancrooModalPage';
+
+
+describe(`Consent self service app`, () => {
+  const acpLoginPage: AcpLoginPage = new AcpLoginPage();
+  const consentPage: ConsentPage = new ConsentPage();
+  const errorPage: ErrorPage = new ErrorPage();
+  const consentSelfServicePage: ConsentSelfServicePage = new ConsentSelfServicePage();
+  const consentSelfServiceApplicationPage: ConsentSelfServiceApplicationPage = new ConsentSelfServiceApplicationPage();
+  const mfaPage: MfaPage = new MfaPage();
+  const financrooLoginPage: FinancrooLoginPage = new FinancrooLoginPage();
+  const financrooWelcomePage: FinancrooWelcomePage = new FinancrooWelcomePage();
+  const financrooModalPage: FinancrooModalPage = new FinancrooModalPage();
+  const financrooAccountsPage: FinancrooAccountsPage = new FinancrooAccountsPage();
+  const financrooInvestmentsPage: FinancrooInvestmentsPage = new FinancrooInvestmentsPage();
+  const financrooContributePage: FinancrooContributePage = new FinancrooContributePage();
+  const environmentVariables: EnvironmentVariables = new EnvironmentVariables();
+
+  before(() => {
+    financrooLoginPage.visit()
+    Urls.clearLocalStorage()
+    financrooLoginPage.visit()
+    financrooLoginPage.login()
+    acpLoginPage.login(Credentials.financrooUsername, Credentials.defaultPassword)
+    financrooWelcomePage.connectSantanderBank()
+    acpLoginPage.login(Credentials.tppUsername, Credentials.defaultPassword)
+    if (environmentVariables.isMfaEnabled()) {
+      mfaPage.typePin()
+    }
+    consentPage.confirm()
+    financrooModalPage.assertThatModalIsDisplayed()
+
+    financrooLoginPage.visit()
+    financrooAccountsPage.assertThatPageIsDisplayed()
+  })
+
+  beforeEach(() => {
+    consentSelfServicePage.visit(true)
+  })
+
+  it(`Happy path with account consent`, () => {
+    acpLoginPage.login(Credentials.tppUsername, Credentials.defaultPassword);
+    consentSelfServicePage.clickOnApplicationCard()
+    consentSelfServiceApplicationPage.expandAccountsTab()
+    consentSelfServiceApplicationPage.checkAccount("94088392") // TODO: 
+    consentSelfServiceApplicationPage.expandAccountConsentRow()
+  })
+
+  it(`Revoke consent`, () => {
+    acpLoginPage.login(Credentials.tppUsername, Credentials.defaultPassword);
+    consentSelfServicePage.clickOnApplicationCard()
+    consentSelfServiceApplicationPage.expandAccountsTab()
+    consentSelfServiceApplicationPage.assertNumberOfConsents(1)
+    consentSelfServiceApplicationPage.expandAccountConsentRow()
+    consentSelfServiceApplicationPage.clickRevokeAccessButton() 
+    consentSelfServiceApplicationPage.assertNumberOfConsents(0)
+  })
+
+  it(`Cancel ACP login`, () => {
+    acpLoginPage.cancel();
+    errorPage.assertError("The user rejected the authentication")
+  })
+
+})

--- a/tests/cypress/integration/obuk/ConsentSelfServiceTests.ts
+++ b/tests/cypress/integration/obuk/ConsentSelfServiceTests.ts
@@ -38,7 +38,7 @@ describe(`Consent self service app`, () => {
     financrooLoginPage.visit()
     financrooLoginPage.login()
     acpLoginPage.login(Credentials.financrooUsername, Credentials.defaultPassword)
-    financrooWelcomePage.connect()
+    financrooWelcomePage.connectGoBank()
     acpLoginPage.login(Credentials.tppUsername, Credentials.defaultPassword)
     if (environmentVariables.isMfaEnabled()) {
       mfaPage.typePin()

--- a/tests/cypress/integration/obuk/FinancrooAccountsTests.ts
+++ b/tests/cypress/integration/obuk/FinancrooAccountsTests.ts
@@ -37,7 +37,7 @@ describe(`Financroo app`, () => {
   ].forEach(accounts => {
     it(`Happy path with accounts: ${accounts}`, () => {
       acpLoginPage.login(Credentials.financrooUsername, Credentials.defaultPassword)
-      financrooWelcomePage.connect()
+      financrooWelcomePage.connectGoBank()
       acpLoginPage.login(Credentials.tppUsername, Credentials.defaultPassword)
       if (environmentVariables.isMfaEnabled()) {
         mfaPage.typePin()
@@ -57,14 +57,14 @@ describe(`Financroo app`, () => {
 
   it(`Cancel on second ACP login`, () => {
     acpLoginPage.login(Credentials.financrooUsername, Credentials.defaultPassword)
-    financrooWelcomePage.connect()
+    financrooWelcomePage.connectGoBank()
     acpLoginPage.cancel()
     errorPage.assertError(`The user rejected the authentication`)
   })
 
   it(`Cancel on consent`, () => {
     acpLoginPage.login(Credentials.financrooUsername, Credentials.defaultPassword)
-    financrooWelcomePage.connect()
+    financrooWelcomePage.connectGoBank()
     acpLoginPage.login(Credentials.tppUsername, Credentials.defaultPassword)
     if (environmentVariables.isMfaEnabled()) {
       mfaPage.typePin()

--- a/tests/cypress/integration/obuk/FinancrooPaymentsTests.ts
+++ b/tests/cypress/integration/obuk/FinancrooPaymentsTests.ts
@@ -33,7 +33,7 @@ describe(`Financroo payments app test`, () => {
     financrooLoginPage.visit()
     financrooLoginPage.login()
     acpLoginPage.login(Credentials.financrooUsername, Credentials.defaultPassword)
-    financrooWelcomePage.connect()
+    financrooWelcomePage.connectGoBank()
     acpLoginPage.login(Credentials.tppUsername, Credentials.defaultPassword)
     if (environmentVariables.isMfaEnabled()) {
       mfaPage.typePin()

--- a/tests/cypress/pages/financroo/FinancrooWelcomePage.ts
+++ b/tests/cypress/pages/financroo/FinancrooWelcomePage.ts
@@ -3,15 +3,29 @@ import {FinancrooConnectAccountPage} from './accounts/FinancrooConnectAccountPag
 export class FinancrooWelcomePage {
   private readonly financrooConnectAccountPage: FinancrooConnectAccountPage = new FinancrooConnectAccountPage();
 
-  public connect(): void {
+  public connectGoBank(): void {
     cy.get(`[class*="connect-button"]`).then(ele => {
       cy.wrap(ele).click()
       if (ele.text().includes(`disconnect`)) {
-        this.connect()
+        this.connectGoBank()
       } else if (!ele.text().includes(`reconnect`)) {
-        this.financrooConnectAccountPage.connectGoBank()
+        this.financrooConnectAccountPage.clickGoBankIcon()
         this.financrooConnectAccountPage.allow()
       }
     })
   }
+
+  public connectSantanderBank(): void {
+    cy.get(`[class*="connect-button"]`).then(ele => {
+      cy.wrap(ele).click()
+      if (ele.text().includes(`disconnect`)) {
+        this.connectSantanderBank()
+      } else if (!ele.text().includes(`reconnect`)) {
+        this.financrooConnectAccountPage.clickSantanderBankIcon()
+        this.financrooConnectAccountPage.allow()
+      }
+    })
+ }
 }
+
+

--- a/tests/cypress/pages/financroo/accounts/FinancrooConnectAccountPage.ts
+++ b/tests/cypress/pages/financroo/accounts/FinancrooConnectAccountPage.ts
@@ -1,10 +1,15 @@
 export class FinancrooConnectAccountPage {
   private readonly goBankLocator: string = `#gobank`;
+  private readonly santanderBankLocator: string = '#santander'; 
   private readonly cancelButtonLocator: string = `#cancel-button`;
   private readonly allowButtonLocator: string = `#allow-button`;
 
-  public connectGoBank(): void {
+  public clickGoBankIcon(): void {
     cy.get(this.goBankLocator).click()
+  }
+
+  public clickSantanderBankIcon(): void {
+    cy.get(this.santanderBankLocator).click()
   }
 
   public allow(): void {


### PR DESCRIPTION
## Description
This PR adds open banking brasil support to the quickstart consent self service application. 

* Added consent retrieval using the ACP OBBR apis
* Added account retrieval using the internal /account api exposed by the mock bank application
* Added consent revocation using the ACP OBBR apis  
* Added cypress tests for retrieving an obbr consent in the self service portal and for revoking that consent

## Type of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)

## Implementation details
