### PR TITLE
Fix OBBR Payment Consent for SAAS

### DIFF
--- a/apps/financroo-tpp/clients.go
+++ b/apps/financroo-tpp/clients.go
@@ -220,8 +220,9 @@ type OBBRConsentClient struct {
 	Accounts acpclient.Client
 	Payments acpclient.Client
 	Signer
+	Config
 }
 
-func NewOBBRConsentClient(accountsClient, paymentsClient acpclient.Client, signer Signer) ConsentClient {
-	return &OBBRConsentClient{accountsClient, paymentsClient, signer}
+func NewOBBRConsentClient(accountsClient, paymentsClient acpclient.Client, signer Signer, config Config) ConsentClient {
+	return &OBBRConsentClient{accountsClient, paymentsClient, signer, config}
 }

--- a/apps/financroo-tpp/consent.go
+++ b/apps/financroo-tpp/consent.go
@@ -342,7 +342,7 @@ func (o *OBBRConsentClient) CreatePaymentConsent(c *gin.Context, req CreatePayme
 	}
 
 	obbrPaymentConsentRequest := ob.BrazilCustomerPaymentConsentRequest{
-		Aud: fmt.Sprintf("%s/open-banking/payments/v1/consents", o.Payments.Config.IssuerURL.String()),
+		Aud: fmt.Sprintf("%s/%s/%s/open-banking/payments/v1/consents", o.Config.ACPURL, o.Config.Tenant, o.Config.ServerID),
 		Iat: time.Now().Unix(),
 		Jti: uuid.New().String(),
 		Iss: "3333-3333-3333-3333",

--- a/apps/financroo-tpp/server.go
+++ b/apps/financroo-tpp/server.go
@@ -48,7 +48,9 @@ func NewServer() (Server, error) {
 		}
 	case "obbr":
 		server.Config.ClientScopes = []string{"accounts", "payments", "openid", "offline_access", "consents"}
-		if server.Clients, err = InitClients(server.Config, NewOBBRSigner, NewOBBRClient, NewOBBRConsentClient); err != nil {
+		if server.Clients, err = InitClients(server.Config, NewOBBRSigner, NewOBBRClient, func(c1 acpclient.Client, c2 acpclient.Client, signer Signer) ConsentClient {
+			return NewOBBRConsentClient(c1, c2, signer, server.Config)
+		}); err != nil {
 			return server, errors.Wrapf(err, "failed to create clients")
 		}
 		if server.LoginURLBuilder, err = NewOBBRLoginURLBuilder(server.Clients.AcpAccountsClient); err != nil {


### PR DESCRIPTION
## Jira task - [AUT-5706](https://cloudentity.atlassian.net/browse/AUT-5706)


## Description
This PR fixes a bug where financroo can't register a payment consent for open banking brasil when running in a saas environment. 

The problem was caused by financroo using the wrong url when constructing the `aud` signature claim. In the obbr payment consent endpoint, ACP constructs a list of valid audiences using the base server url, and not the mtls alias (which is what financroo was using).

## Type of changes
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)

## Implementation details
