### PR TITLE
Override Internal Bank Accounts Endpoint for CDR Consent Page

### DIFF
--- a/consent/consent-page/main.go
+++ b/consent/consent-page/main.go
@@ -71,7 +71,8 @@ type OtpConfig struct {
 }
 
 type BankClientConfig struct {
-	URL          *url.URL `env:"BANK_URL"`
+	URL          *url.URL `env:"BANK_URL,required"`
+	AccountsURL  *url.URL `env:"BANK_ACCOUNTS_ENDPOINT"`
 	CertFile     string   `env:"BANK_CLIENT_CERT_FILE" envDefault:"/tpp_cert.pem"`
 	KeyFile      string   `env:"BANK_CLIENT_KEY_FILE" envDefault:"/tpp_key.pem"`
 	TokenURL     string   `env:"BANK_CLIENT_TOKEN_URL"`

--- a/docker-compose.cdr.yaml
+++ b/docker-compose.cdr.yaml
@@ -85,6 +85,7 @@ services:
       - BANK_CLIENT_SCOPES=bank:accounts.basic:read,bank:accounts.detail:read
       - BANK_CLIENT_CERT_FILE=/tpp_cert.pem
       - BANK_CLIENT_KEY_FILE=/tpp_key.pem
+      - BANK_ACCOUNTS_ENDPOINT=http://bank:8070/internal/accounts
 
     depends_on:
       configuration:


### PR DESCRIPTION
## Description
This PR adds a new configuration option to completely override the accounts endpoint that the cdr consent page calls, instead of the prior behavior of calling `bankURL/internal/accounts`

This is controlled by a new environment variable in the cdr consent page service called `BANK_ACCOUNTS_ENDPOINT`

## Type of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)

