### PR TITLE
Add Hint To Static IDP Login Pages

### DIFF
--- a/data/imports/bank-customers.tmpl
+++ b/data/imports/bank-customers.tmpl
@@ -10,6 +10,9 @@ idps:
   authorization_server_id: bank-customers
   name: Sandbox IDP
   method: static
+  settings: 
+    static: 
+      hint: true
   credentials:
     static:
       users:

--- a/data/imports/cdr.tmpl
+++ b/data/imports/cdr.tmpl
@@ -118,6 +118,9 @@ idps:
     target: customer_id
     type: string
     allow_weak_decoding: false
+  settings: 
+    static: 
+      hint: true
   credentials:
     static:
       users:

--- a/data/imports/openbanking-br.tmpl
+++ b/data/imports/openbanking-br.tmpl
@@ -115,6 +115,9 @@ idps:
     target: cnpj
     type: string_array
     allow_weak_decoding: false
+  settings: 
+    static: 
+      hint: true
   credentials:
     static:
       users:

--- a/data/imports/openbanking-uk.tmpl
+++ b/data/imports/openbanking-uk.tmpl
@@ -18,6 +18,9 @@ idps:
   id: bugkgai3g9kregtu04u0
   name: Sandbox IDP
   method: static
+  settings: 
+    static: 
+      hint: true
   credentials:
     static:
       users:


### PR DESCRIPTION
## Description
This PR adds hints to the static idp login pages so that users won't have to look elsewhere for login credentials when they are going through the app flows. 

## Type of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)

