### PR TITLE
Bump acp and data recipient apps

### DIFF
--- a/.env-local
+++ b/.env-local
@@ -14,7 +14,7 @@ ACP_BASE_URL=authorization.cloudentity.com:8443
 ACP_MTLS_URL=https://authorization.cloudentity.com:8443
 
 # acp version
-ACP_VERSION=2.3.0-0425811
+ACP_VERSION=2.3.0-61e357e
 
 # host where apps are deployed
 APP_HOST=localhost

--- a/Makefile
+++ b/Makefile
@@ -135,3 +135,6 @@ generate-cdr-clients: start-runner
 obbr:
 	docker-compose -f docker-compose.acp.local.yaml -f conformance/docker-compose.obb.yaml -f conformance/docker-compose.fapi.yaml ${cmd}
 
+.PHONY: bump_acp
+bump_acp:
+	./scripts/bump_acp.sh

--- a/docker-compose.cdr.yaml
+++ b/docker-compose.cdr.yaml
@@ -43,7 +43,7 @@ services:
 
   mock-data-recipient:
     container_name: mock-data-recipient
-    image: docker.cloudentity.io/cdr-mock-data-recipient:0.0.10
+    image: docker.cloudentity.io/cdr-mock-data-recipient:0.0.11
     networks:
       default:
         aliases:

--- a/scripts/bump_acp.sh
+++ b/scripts/bump_acp.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+latest_tag=$(docker images --format '{{.Tag}}' docker.cloudentity.io/acp | head -n 1)
+./scripts/override_env.sh ACP_VERSION $latest_tag


### PR DESCRIPTION
## Jira task - PUT_JIRA_LINK_HERE

## Description

Bump acp and data recipient apps.
Data recipient corresponding PR: https://github.com/cloudentity/mock-data-recipient/pull/7
Add a simple script to bump acp docker image locally.

## Information for QA
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Implementation details

<!--- Describe implementation details if needed -->

## Screenshots (if appropriate):
