### PR TITLE
AUT-6324 - feature/AUT-6324-refactor-clean-saas-script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,11 +11,11 @@ pipeline {
     }
     environment {
         VERIFY_TEST_RUNNER_TIMEOUT_MS = 80000
-        SAAS_TENANT_ID = 'amfudxn6-qa-us-east-1-ob-quickstart'
-        SAAS_CLIENT_ID = credentials('OPENBANKING_CONFIGURATION_CLIENT_ID')
-        SAAS_CLIENT_SECRET = credentials('OPENBANKING_CONFIGURATION_CLIENT_SECRET')
-        SAAS_CLEANUP_CLIENT_ID = credentials('OPENBANKING_CLEANUP_CLIENT_ID')
-        SAAS_CLEANUP_CLIENT_SECRET = credentials('OPENBANKING_CLEANUP_CLIENT_SECRET')
+        SAAS_TENANT_ID = 'amfudxn6-qa-us-east-1-obqs-test'
+        SAAS_CLIENT_ID = 'c8sphc5fjs58tv4q8mlg'
+        SAAS_CLIENT_SECRET = 'HWaJeEQI2rajy0KvVF-E1S_RIem-43wBYnvDY_LXv_A'
+        SAAS_CLEANUP_CLIENT_ID = 'c91dqlso28ai5c87hsig'
+        SAAS_CLEANUP_CLIENT_SECRET = 'kFJkc9upMu6oQ_I_2GD1kmA_jgp0iPrHWvVi-15vD28'
         NOTIFICATION_CHANNEL = credentials('OPENBANKING_NOTIFICATION_CHANNEL')
         DEBUG = 'true'
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,11 +11,11 @@ pipeline {
     }
     environment {
         VERIFY_TEST_RUNNER_TIMEOUT_MS = 80000
-        SAAS_TENANT_ID = 'amfudxn6-qa-us-east-1-obqs-test'
-        SAAS_CLIENT_ID = 'c8sphc5fjs58tv4q8mlg'
-        SAAS_CLIENT_SECRET = 'HWaJeEQI2rajy0KvVF-E1S_RIem-43wBYnvDY_LXv_A'
-        SAAS_CLEANUP_CLIENT_ID = 'c91dqlso28ai5c87hsig'
-        SAAS_CLEANUP_CLIENT_SECRET = 'kFJkc9upMu6oQ_I_2GD1kmA_jgp0iPrHWvVi-15vD28'
+        SAAS_TENANT_ID = 'amfudxn6-qa-us-east-1-ob-quickstart'
+        SAAS_CLIENT_ID = credentials('OPENBANKING_CONFIGURATION_CLIENT_ID')
+        SAAS_CLIENT_SECRET = credentials('OPENBANKING_CONFIGURATION_CLIENT_SECRET')
+        SAAS_CLEANUP_CLIENT_ID = credentials('OPENBANKING_CLEANUP_CLIENT_ID')
+        SAAS_CLEANUP_CLIENT_SECRET = credentials('OPENBANKING_CLEANUP_CLIENT_SECRET')
         NOTIFICATION_CHANNEL = credentials('OPENBANKING_NOTIFICATION_CHANNEL')
         DEBUG = 'true'
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,14 +47,13 @@ pipeline {
         stage('CDR Tests') {
             steps {
                 script {
+                    sh 'make clean'
                     try {
                         sh 'make run-cdr-local'
                         sh 'make run-cdr-tests-headless'
                     } catch(exc) {
                         captureDockerLogs()
                         unstable('CDR Tests failed')
-                    } finally {
-                        sh 'make clean'
                     }
                 }
             }
@@ -62,14 +61,13 @@ pipeline {
         stage('FDX Tests with disabled MFA') {
             steps {
                 script {
+                    sh 'make clean'
                     try {
                         sh 'make disable-mfa run-fdx-local'
                         sh 'make run-fdx-tests-headless'
                     } catch(exc) {
                         captureDockerLogs()
                         unstable('FDX Tests with disabled MFA failed')
-                    } finally {
-                        sh 'make clean'
                     }
                 }
             }
@@ -77,14 +75,13 @@ pipeline {
         stage('FDX Tests with enabled MFA') {
             steps {
                 script {
+                    sh 'make clean'
                     try {
                         sh 'make enable-mfa run-fdx-local'
                         sh 'make run-fdx-tests-headless'
                     } catch(exc) {
                         captureDockerLogs()
                         unstable('FDX Tests with enabled MFA failed')
-                    } finally {
-                        sh 'make clean'
                     }
                 }
             }
@@ -92,14 +89,13 @@ pipeline {
         stage('OBUK Tests with disabled MFA') {
             steps {
                 script {
+                    sh 'make clean'
                     try {
                         sh 'make disable-mfa run-obuk-local'
                         sh 'make run-obuk-tests-headless'
                     } catch(exc) {
                         captureDockerLogs()
                         unstable('OBUK Tests with disabled MFA failed')
-                    } finally {
-                        sh 'make clean'
                     }
                 }
             }
@@ -107,14 +103,13 @@ pipeline {
         stage('OBUK Tests with enabled MFA') {
             steps {
                 script {
+                    sh 'make clean'
                     try {
                         sh 'make enable-mfa run-obuk-local'
                         sh 'make run-obuk-tests-headless'
                     } catch(exc) {
                         captureDockerLogs()
                         unstable('OBUK Tests with enabled MFA failed')
-                    } finally {
-                        sh 'make clean'
                     }
                 }
             }
@@ -122,14 +117,13 @@ pipeline {
         stage('OBBR Tests with disabled MFA') {
             steps {
                 script {
+                    sh 'make clean'
                     try {
                         sh 'make disable-mfa run-obbr-local'
                         sh 'make run-obbr-tests-headless'
                     } catch(exc) {
                         captureDockerLogs()
                         unstable('OBBR Tests with disabled MFA failed')
-                    } finally {
-                        sh 'make clean'
                     }
                 }
             }
@@ -137,14 +131,13 @@ pipeline {
         stage('OBBR Tests with enabled MFA') {
             steps {
                 script {
+                    sh 'make clean'
                     try {
                         sh 'make enable-mfa run-obbr-local'
                         sh 'make run-obbr-tests-headless'
                     } catch(exc) {
                         captureDockerLogs()
                         unstable('OBBR Tests with enabled MFA failed')
-                    } finally {
-                        sh 'make clean'
                     }
                 }
             }
@@ -152,14 +145,13 @@ pipeline {
         stage('SaaS FDX Tests') {
             steps {
                 script {
+                    sh 'make clean-saas'
                     try {
                         sh 'make disable-mfa set-saas-configuration run-fdx-saas'
                         sh 'make run-saas-fdx-tests-headless'
                     } catch(exc) {
                         captureDockerLogs()
                         unstable('SaaS FDX Tests failed')
-                    } finally {
-                        sh 'make clean-fdx-saas'
                     }
                 }
             }
@@ -167,14 +159,13 @@ pipeline {
         stage('SaaS OBUK Tests') {
             steps {
                 script {
+                    sh 'make clean-saas'
                     try {
                         sh 'make disable-mfa set-saas-configuration run-obuk-saas'
                         sh 'make run-saas-obuk-tests-headless'
                     } catch(exc) {
                         captureDockerLogs()
                         unstable('SaaS OBUK Tests failed')
-                    } finally {
-                        sh 'make clean-obuk-saas'
                     }
                 }
             }
@@ -182,14 +173,13 @@ pipeline {
         stage('SaaS OBBR Tests') {
             steps {
                 script {
+                    sh 'make clean-saas'
                     try {
                         sh 'make disable-mfa set-saas-configuration run-obbr-saas'
                         sh 'make run-saas-obbr-tests-headless'
                     } catch(exc) {
                         captureDockerLogs()
                         unstable('SaaS OBBR Tests failed')
-                    } finally {
-                        sh 'make clean-obbr-saas'
                     }
                 }
             }
@@ -197,14 +187,13 @@ pipeline {
         // stage('SaaS CDR Tests') {
         //     steps {
         //         script {
+        //             sh 'make clean-saas'
         //             try {
         //                 sh 'make disable-mfa set-saas-configuration run-cdr-saas'
         //                 sh 'make run-saas-cdr-tests-headless'
         //             } catch(exc) {
         //                 captureDockerLogs()
         //                 unstable('SaaS CDR Tests failed')
-        //             } finally {
-        //                 sh 'make clean-cdr-saas'
         //             }
         //         }
         //     }

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,9 @@ ifeq (${DEBUG},true)
 	rm -fr mount/cdr/*
 endif
 
-# obuk, obbr, fdx
-clean-%-saas: start-runner
+clean-saas: start-runner
 	docker exec quickstart-runner sh -c \
     "go run ./scripts/go/clean_saas.go \
-        -spec=$* \
         -tenant=${SAAS_TENANT_ID} \
         -cid=${SAAS_CLEANUP_CLIENT_ID} \
         -csec=${SAAS_CLEANUP_CLIENT_SECRET}"

--- a/scripts/go/clean_saas.go
+++ b/scripts/go/clean_saas.go
@@ -89,12 +89,12 @@ func doRequest(client *http.Client, request *http.Request, statusCode int) (resp
 		return response, err
 	}
 
-	if response.StatusCode == http.StatusNotFound {
+	if http.StatusNotFound == response.StatusCode {
 		fmt.Printf("INFO: The response finished with status code '%d'\n", response.StatusCode)
 		return response, nil
 	} else if response.StatusCode != statusCode {
 		fmt.Printf("INFO: The response finished with status code '%d'\n", response.StatusCode)
 	}
-
+	fmt.Printf("INFO: The response finished with status code '%d'\n", response.StatusCode)
 	return response, nil
 }

--- a/scripts/go/clean_saas.go
+++ b/scripts/go/clean_saas.go
@@ -17,10 +17,10 @@ import (
 )
 
 var (
-	tenantID              = flag.String("tenant", "none", "Openbanking SaaS tenant ID")
-	adminClientID         = flag.String("cid", "none", "Openbanking SaaS admin client ID")
-	adminClientSecret     = flag.String("csec", "none", "Openbanking SaaS admin client secret")
-	
+	tenantID          = flag.String("tenant", "none", "Openbanking SaaS tenant ID")
+	adminClientID     = flag.String("cid", "none", "Openbanking SaaS admin client ID")
+	adminClientSecret = flag.String("csec", "none", "Openbanking SaaS admin client secret")
+
 	defaultServicesIDs    = []string{"system", "admin", "default", "developer", "demo"}
 	openbankingClientsIDs = []string{"buc3b1hhuc714r78env0", "bv2fe0tpfc67lmeti340", "bv0ocudfotn6edhsiu7g"}
 )
@@ -28,6 +28,7 @@ var (
 type Server struct {
 	ID string `json:"id"`
 }
+
 type ServersResponse struct {
 	Servers []Server `json:"servers"`
 }
@@ -41,7 +42,7 @@ func main() {
 		err          error
 		tURL         *url.URL
 		tenantURLRaw string
-		serversIDs []string
+		serversIDs   []string
 	)
 
 	tenantURLRaw = fmt.Sprintf("https://%s.us.authz.cloudentity.io", *tenantID)
@@ -106,7 +107,6 @@ func main() {
 		response.Body.Close()
 		fmt.Printf("INFO: clientwith ID: '%s' was successfully removed\n", cid)
 	}
-
 }
 
 func doRequest(client *http.Client, request *http.Request, statusCode int) (response *http.Response, err error) {
@@ -121,7 +121,7 @@ func doRequest(client *http.Client, request *http.Request, statusCode int) (resp
 	return response, nil
 }
 
-func getCurrentServersIDs(response *http.Response) (IDs []string, err error) {
+func getCurrentServersIDs(response *http.Response) (ids []string, err error) {
 	var body []byte
 	if body, err = io.ReadAll(response.Body); err != nil {
 		log.Fatalf("failed to get body: %v", err)
@@ -130,13 +130,15 @@ func getCurrentServersIDs(response *http.Response) (IDs []string, err error) {
 	response.Body.Close()
 
 	var serversResponse ServersResponse
-	json.Unmarshal([]byte(body), &serversResponse)
-
-	for _, server := range serversResponse.Servers {
-		IDs = append(IDs, server.ID)
+	if err = json.Unmarshal(body, &serversResponse); err != nil {
+		log.Fatalf("failed to unmarshal body: %v", response.Body)
 	}
 
-	return IDs, nil
+	for _, server := range serversResponse.Servers {
+		ids = append(ids, server.ID)
+	}
+
+	return ids, nil
 }
 
 func getServersIDsToDelete(actualIDs []string) (expectedIDs []string) {


### PR DESCRIPTION
## Jira task - [AUT-6324](https://cloudentity.atlassian.net/browse/AUT-6324)


## Description

Currently to execute  `clean_saas.go` the `obSpec` flag must be provided - this implementation depends on fixed list with workspace ID. 

Additionally with current solution, the clean up mechanism in the Jenkins plan is implemented at the end of the stage, not at the beginning (which is a bad solution in case of e.g.:  network connection failures).

TODO refactor:

- update `clean_saas.go` script to:
  - remove `obSpec` flag
  - GET the list of all available Servers 
  - exclude the default servers such as: `System`, `Admin`, `Default` etc.
  - remove non-default servers only 
- update `Jenkisfile` with `clean-saas` option implemented at the beginning of every SaaS Test stage
- update `Jenkisfile with `clean` option implemented at the beginning of every local Test stage

## Information for QA
N/A