### PR TITLE
Added 20 minutes timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
             steps {
                 sh 'rm -f docker-compose.log'
                 sh 'make clean'
+                sleep(time:20, unit:"MINUTES")
                 sh 'make lint'
                 sh 'make stop-runner'
                 sh 'make build'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,6 @@ pipeline {
             steps {
                 sh 'rm -f docker-compose.log'
                 sh 'make clean'
-                sleep(time:20, unit:"MINUTES")
                 sh 'make lint'
                 sh 'make stop-runner'
                 sh 'make build'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,9 @@ pipeline {
             steps {
                 sh 'rm -f docker-compose.log'
                 sh 'make clean'
-                sh 'make lint'
+                retry(3) {
+                    sh 'make lint'
+                }
                 sh 'make stop-runner'
                 sh 'make build'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,9 +39,7 @@ pipeline {
             steps {
                 sh 'rm -f docker-compose.log'
                 sh 'make clean'
-                retry(3) {
-                    sh 'make lint'
-                }
+                sh 'make lint'
                 sh 'make stop-runner'
                 sh 'make build'
             }

--- a/build/runner.dockerfile
+++ b/build/runner.dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.18 as base
 ENV GO111MODULE=on
 WORKDIR /code
-RUN go install github.com/go-swagger/go-swagger/cmd/swagger@v0.28.0
+RUN GOPROXY="direct" go install github.com/go-swagger/go-swagger/cmd/swagger@v0.28.0
 
 ARG UID=1000
 ARG GID=1000

--- a/build/runner.dockerfile
+++ b/build/runner.dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.18 as base
 ENV GO111MODULE=on
 WORKDIR /code
-RUN go install github.com/go-swagger/go-swagger/cmd/swagger@v0.26.1
+RUN go install github.com/go-swagger/go-swagger/cmd/swagger@v0.28.0
 
 ARG UID=1000
 ARG GID=1000


### PR DESCRIPTION
## Jira task - [AUT-6883](https://cloudentity.atlassian.net/browse/AUT-6883)

## Description
Recently openbanking-quickstart pipeline is failing due to:

```
#7 [3/9] RUN go install github.com/go-swagger/go-swagger/cmd/swagger@v0.26.1
#7 sha256:19c5274c5e235776abde46ed591ffaafd954005961c48b2b749514e8b38535a8
#7 12.37 go: github.com/go-swagger/go-swagger/cmd/swagger@v0.26.1: github.com/go-swagger/go-swagger/cmd/swagger@v0.26.1: Get "https://proxy.golang.org/github.com/go-swagger/go-swagger/cmd/swagger/@v/v0.26.1.info": 
#7 ERROR: executor failed running [/bin/sh -c go install github.com/go-swagger/go-swagger/cmd/swagger@v0.26.1]: exit code: 1
------
 > [3/9] RUN go install github.com/go-swagger/go-swagger/cmd/swagger@v0.26.1:
------
executor failed running [/bin/sh -c go install github.com/go-swagger/go-swagger/cmd/swagger@v0.26.1]: exit code: 1
make: *** [Makefile:102: start-runner] Error 1
script returned exit code 2
```
Implementation details:
- Updated go-swagger version to `0.28.0`
- Added `GOPROXY="direct"` to `go install github.com/go-swagger/go-swagger/cmd/swagger@v0.28.0` command


## Information for QA
N/A

