### PR TITLE
AUT-7148: Fix 8082 port conflict with ACP

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,8 @@ pipeline {
                         cd tests && yarn install
                  '''
                  sh 'docker-compose version'
-
+                 sh "docker rm -f \$(docker ps -aq) || true"
+                 
                  retry(3) {
                    sh "make run-tests-verify"
                  }


### PR DESCRIPTION
## Jira task - [PUT_JIRA_LINK_HERE](https://cloudentity.atlassian.net/browse/AUT-7148)

## Description
On Jenkins Ci there is a conflict between ACP and Openbanking Quickstart on port 8082. It looks like on Ci worker there are sometimes leftovers from ACP builds and port is already used which cause errors.
Solution: in Jenkinsfile remove all containers as a preparation step.
<!--- Describe what this feature does
  REQUIRED
  USED IN RELEASE NOTES
-->

## Information for QA
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Implementation details

<!--- Describe implementation details if needed -->

## Screenshots (if appropriate):
