### PR TITLE
Added Developer TPP Error page for consent rejection

### DIFF
--- a/apps/developer-tpp/assets/style.css
+++ b/apps/developer-tpp/assets/style.css
@@ -347,6 +347,35 @@ h6 {
   background: rgba(4, 123, 209, 0.05);
 }
 
+.aut-reject-demo {
+  display: block;
+  margin: 20px 0;
+  border-radius: 4px;
+  text-align: center;
+  background: rgba(185 , 185, 185, 0.2);
+}
+
+.aut-reject-icon-demo {
+  margin: 10px 10px;
+  padding: 5px 5px 5px 5px;
+  font-size: 48px;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.aut-reject-title-demo {
+  text-transform: capitalize;
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 36px;
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.aut-reject-subtitle-demo {
+  padding: 10px 0;
+  font-size: 14px;
+  color: rgba(0, 0, 0, 0.5);
+}
+
 .aut-demo-info {
   display: flex;
   margin: 10px 0;

--- a/apps/developer-tpp/handler.go
+++ b/apps/developer-tpp/handler.go
@@ -133,6 +133,15 @@ func (s *Server) Callback() func(*gin.Context) {
 			return
 		}
 
+		if responseClaims.Error == "rejected" {
+			data["error"] = string(responseClaims.Error)
+			data["error_cause"] = string(responseClaims.ErrorCause)
+			data["error_description"] = string(responseClaims.ErrorDescription)
+			data["trace_id"] = string(responseClaims.TraceId)
+			c.HTML(http.StatusBadRequest, s.GetTemplate("consent-rejected.tmpl"), data)
+			return
+		}
+
 		if responseClaims.Error != "" {
 			c.String(http.StatusBadRequest, fmt.Sprintf("acp returned an error: %s: %s", responseClaims.Error, responseClaims.ErrorDescription))
 			return

--- a/apps/developer-tpp/templates/fdx/fdx-consent-rejected.tmpl
+++ b/apps/developer-tpp/templates/fdx/fdx-consent-rejected.tmpl
@@ -17,7 +17,7 @@
     <span>TPP sample app</span>
   </div>
   <div class="aut-banner-contact">
-    <button class="mdc-button mdc-button--raised" onclick="onRetry()" id="fdx-auth-try-again-button">
+    <button class="mdc-button mdc-button--raised" onclick="onRetry()" id="fdx-consent-error-try-again-button">
       <div class="mdc-button__ripple"></div>
       <span class="mdc-button__label">Try again</span>
     </button>

--- a/apps/developer-tpp/templates/fdx/fdx-consent-rejected.tmpl
+++ b/apps/developer-tpp/templates/fdx/fdx-consent-rejected.tmpl
@@ -1,0 +1,46 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
+
+<html>
+<head>
+  <link rel="stylesheet" href="/assets/material-components-web.min.css">
+  <script src="/assets/material-components-web.min.js"></script>
+  <link href="/assets/fonts.css" rel="stylesheet">
+  <link href="/assets/material-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="/assets/style.css">
+  <title>TPP sample app</title>
+</head>
+
+<body>
+<div class="aut-banner">
+  <div class="aut-banner-logo">
+    <img src="/assets/images/cloudentity-logo-short.png" alt="Cloudentity ACP">
+    <span>TPP sample app</span>
+  </div>
+  <div class="aut-banner-contact">
+    <button class="mdc-button mdc-button--raised" onclick="onRetry()" id="fdx-auth-try-again-button">
+      <div class="mdc-button__ripple"></div>
+      <span class="mdc-button__label">Try again</span>
+    </button>
+  </div>
+</div>
+
+<div class="aut-container" style="padding: 5px; width: 1024px;">
+  <div class="aut-reject-demo">
+    <div class="material-icons aut-reject-icon-demo">error_outline</div>
+    <div class="aut-reject-title-demo" id="fdx-consent-error">{{ .error }}</div>
+    <div class="aut-reject-subtitle-demo" id="fdx-consent-error-details">
+      <p id="fdx-consent-error-description"><b>description: </b>{{ .error_description }}</p>
+      <p id="fdx-consent-error-cause"><b>cause: </b>{{ .error_cause }}</p>
+      <p id="fdx-consent-trace-id"><b>ID: </b>{{ .trace_id }}</p>
+    </div>
+  </div>
+</div>
+
+<script>
+  function onRetry () {
+    window.location.href = "/";
+  }
+</script>
+
+</body>
+</html>

--- a/consent/consent-page/fdx_account_access_handler.go
+++ b/consent/consent-page/fdx_account_access_handler.go
@@ -119,6 +119,8 @@ func (s *FDXAccountAccessConsentHandler) DenyConsent(c *gin.Context, loginReques
 				ID:         loginRequest.ID,
 				LoginState: loginRequest.State,
 				Error:      "rejected",
+				ErrorCause: "consent_rejected",
+				ErrorDescription: "The user rejected the authentication.",
 				StatusCode: 403,
 			}),
 		nil,

--- a/tests/cypress/integration/fdx/FdxTppConsentAdminTests.ts
+++ b/tests/cypress/integration/fdx/FdxTppConsentAdminTests.ts
@@ -5,7 +5,7 @@ import { FdxTppLandingPage } from "../../pages/fdx-tpp/FdxTppLandingPage";
 import { FdxTppIntentRegisteredPage } from "../../pages/fdx-tpp/FdxTppIntentRegisteredPage";
 import { FdxTppAuthenticatedPage } from "../../pages/fdx-tpp/FdxTppAuthenticatedPage";
 import { ConsentAdminPage } from "../../pages/consent-admin/ConsentAdminPage";
-import { ErrorPage } from "../../pages/ErrorPage";
+import { FdxTppErrorPage } from "../../pages/fdx-tpp/FdxTppErrorPage";
 
 describe(`FDX TPP Consent admin portal tests`, () => {
   const fdxTppLandingPage: FdxTppLandingPage = new FdxTppLandingPage();
@@ -14,7 +14,7 @@ describe(`FDX TPP Consent admin portal tests`, () => {
   const acpLoginPage: AcpLoginPage = new AcpLoginPage();
   const accountConsentPage: AccountConsentPage = new AccountConsentPage();
   const consentAdminPage: ConsentAdminPage = new ConsentAdminPage();
-  const errorPage: ErrorPage = new ErrorPage();
+  const fdxTppErrorPage: FdxTppErrorPage = new FdxTppErrorPage();
 
   beforeEach(() => {
     fdxTppLandingPage.visit();
@@ -106,8 +106,11 @@ describe(`FDX TPP Consent admin portal tests`, () => {
     accountConsentPage.assertPermissions(4);
     accountConsentPage.clickCancel();
 
-    // UI error page improvements AUT-5845
-    errorPage.assertError(`acp returned an error: rejected:`);
+    fdxTppErrorPage.assertThatErrorPageIsDisplayed(
+      `rejected`,
+      `The user rejected the authentication.`,
+      `consent_rejected`
+    );
   });
 
   async function acceptConsentWithIds(

--- a/tests/cypress/integration/saas/fdx/SmokeFdxTppConsentAdminTests.ts
+++ b/tests/cypress/integration/saas/fdx/SmokeFdxTppConsentAdminTests.ts
@@ -5,7 +5,7 @@ import { FdxTppLandingPage } from "../../../pages/fdx-tpp/FdxTppLandingPage";
 import { FdxTppIntentRegisteredPage } from "../../../pages/fdx-tpp/FdxTppIntentRegisteredPage";
 import { FdxTppAuthenticatedPage } from "../../../pages/fdx-tpp/FdxTppAuthenticatedPage";
 import { ConsentAdminPage } from "../../../pages/consent-admin/ConsentAdminPage";
-import { ErrorPage } from "../../../pages/ErrorPage";
+import { FdxTppErrorPage } from "../../../pages/fdx-tpp/FdxTppErrorPage";
 
 describe(`FDX TPP Consent admin portal tests`, () => {
   const fdxTppLandingPage: FdxTppLandingPage = new FdxTppLandingPage();
@@ -14,7 +14,7 @@ describe(`FDX TPP Consent admin portal tests`, () => {
   const acpLoginPage: AcpLoginPage = new AcpLoginPage();
   const accountConsentPage: AccountConsentPage = new AccountConsentPage();
   const consentAdminPage: ConsentAdminPage = new ConsentAdminPage();
-  const errorPage: ErrorPage = new ErrorPage();
+  const fdxTppErrorPage: FdxTppErrorPage = new FdxTppErrorPage();
 
   beforeEach(() => {
     fdxTppLandingPage.visit();
@@ -106,8 +106,11 @@ describe(`FDX TPP Consent admin portal tests`, () => {
     accountConsentPage.assertPermissions(4);
     accountConsentPage.clickCancel();
 
-    // UI error page improvements AUT-5845
-    errorPage.assertError(`acp returned an error: rejected:`);
+    fdxTppErrorPage.assertThatErrorPageIsDisplayed(
+      `rejected`,
+      `The user rejected the authentication.`,
+      `consent_rejected`
+    );
   });
 
   async function acceptConsentWithIds(

--- a/tests/cypress/pages/fdx-tpp/FdxTppErrorPage.ts
+++ b/tests/cypress/pages/fdx-tpp/FdxTppErrorPage.ts
@@ -1,0 +1,24 @@
+export class FdxTppErrorPage {
+  private readonly errorTitleLocator: string = `#fdx-consent-error`;
+  private readonly errorDescriptionLocator: string = `#fdx-consent-error-description`;
+  private readonly errorCauseLocator: string = `#fdx-consent-error-cause`;
+  private readonly traceIdLocator: string = `#fdx-consent-trace-id`;
+  private readonly tryNextButtonLocator: string = `#fdx-consent-error-try-again-button`;
+
+
+  public assertThatErrorPageIsDisplayed(error: string, description: string, cause: string): void {
+    cy.get(this.tryNextButtonLocator, { timeout: 3000 }).should("be.visible");
+    cy.get(this.errorTitleLocator).contains(error);
+    cy.get(this.errorDescriptionLocator).contains("description: " + description);
+    cy.get(this.errorCauseLocator).contains("cause: " + cause);
+    cy.get(this.traceIdLocator).then((element) => {
+      let text: string = element.text();
+      expect(text).to.match(/ID\: [a-zA-Z0-9]+/);
+    })
+    
+  }
+
+  public clickTryNext(): void {
+    cy.get(this.tryNextButtonLocator).click();
+  }
+}

--- a/utils/response_mode_handler.go
+++ b/utils/response_mode_handler.go
@@ -12,7 +12,9 @@ type ResponseData struct {
 	State            string `json:"state"`
 	Code             string `json:"code"`
 	Error            string `json:"error"`
+	ErrorCause       string `json:"error_cause"`
 	ErrorDescription string `json:"error_description"`
+	TraceId			 string `json:"trace_id"`
 }
 
 func (r *ResponseData) Valid() error {
@@ -38,7 +40,9 @@ func GetResponseDataFromQuery(r *http.Request) (ResponseData, error) {
 		Code:             r.URL.Query().Get("code"),
 		State:            r.URL.Query().Get("state"),
 		Error:            r.URL.Query().Get("error"),
+		ErrorCause:       r.URL.Query().Get("error_cause"),
 		ErrorDescription: r.URL.Query().Get("error_description"),
+		TraceId:          r.URL.Query().Get("trace_id"),
 	}, nil
 }
 


### PR DESCRIPTION
## Jira task - [AUT-7576](https://cloudentity.atlassian.net/browse/AUT-7576)

## Implementation details (internal)

**Case**  - deny `TPP SAMPLE APP` authorization flow by rejecting consent on `Go Bank` page 

Replace raw error page when consent on Go Bank page was rejected (`error: access_denied: rejected`) and replace it with new Developer TPP template.

- Updated implementation for `DenyConsent` case callback in Developer TPP app in `FDX`, _[TBA] ..._ specifications
- Added new templates for Developer TPP app:
-- FDX - `fdx-consent-rejected.tmpl`
-- _[TBA]_
- Updated test Cypress test for consent rejection in `FDX`, _[TBA] ..._ specifications

## Information for QA

N/A

## Additional QA Procedures (Optional)

N/A

## Screenshots (if appropriate):
- old page 
![image](https://user-images.githubusercontent.com/72209717/201343665-d6164772-e359-4e58-9aea-324bb2747f5c.png)

- new page
![image](https://user-images.githubusercontent.com/72209717/201343707-7424c143-b975-4ef8-8bee-e0094c5c622c.png)
