### PR TITLE
bugfix/AUT-7633

### DIFF
--- a/consent/self-service-portal/fdx_consent_impl.go
+++ b/consent/self-service-portal/fdx_consent_impl.go
@@ -70,11 +70,10 @@ func (o *FDXConsentImpl) getClients(response *system.ListClientsSystemOK) []Clie
 }
 
 func (o *FDXConsentImpl) getConsents(response *f_d_x.ListFDXConsentsOK) []Consent {
-	var (
-		consents   []Consent
-		accountIDs []string
-	)
+	var consents []Consent
+
 	for _, consent := range response.Payload.Consents {
+		var accountIDs []string
 		if consent.Status == "Rejected" || consent.Status == "Revoked" {
 			continue
 		}

--- a/tests/cypress/integration/saas/obbr/SmokeFinancrooAccountsTests.ts
+++ b/tests/cypress/integration/saas/obbr/SmokeFinancrooAccountsTests.ts
@@ -48,6 +48,7 @@ describe(`Financroo app`, () => {
       financrooAccountsPage.disconnectAccounts();
 
       financrooWelcomePage.assertThatConnectBankPageIsDisplayed();
+      cy.wait(3000); // Workaround due to pipeline issues >>> AUT-6292
     });
   });
 

--- a/tests/cypress/integration/saas/obuk/SmokeFinancrooAccountsTests.ts
+++ b/tests/cypress/integration/saas/obuk/SmokeFinancrooAccountsTests.ts
@@ -46,6 +46,7 @@ describe(`Smoke Financroo app`, () => {
       financrooAccountsPage.disconnectAccounts();
 
       financrooWelcomePage.assertThatConnectBankPageIsDisplayed();
+      cy.wait(3000); // Workaround due to pipeline issues >>> AUT-6292
     });
   });
 


### PR DESCRIPTION
## Jira task - [PUT_JIRA_LINK_HERE](https://cloudentity.atlassian.net/browse/AUT-7633)

## Release Notes Description (public)
The bug was that consent self-service portal displayed wrong (too many) accounts for some consents when there where more than one consent to display.

After the fix for each cosent only proper list of its account is displayed.


<!--- DESCRIPTION USED IN THE RELEASE NOTES

Remove this comment and replace it with the description of your changes for an external audience. 
This description will be pulled into public release notes.

1. What changes are you introducing? Be clear and provide a detailed overview of your changes.
2. Why are you introducing the changes? Make the intent of the changes clear.
    - What do those changes mean for our end users?
    - Why should they care?
    - What is the context of your changes?

Additionally:

- If your changes are breaking changes, provide information on how the change affects our customers and what is required from them to be updated.
  If you think a migration guide would be useful, let TWs know in advance.
- If your changes deprecate an API, provide what is the alternative for our customers (if it exists). State clearly that an API became deprecated.
-->

## Implementation details (internal)

<!--- Describe technical implementation details for peer reviewers -->

## Information for QA

<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->

- [x] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Screenshots (if appropriate):
