### PR TITLE
AUT-7676 Remove app status form consent self-service

### DIFF
--- a/consent/self-service-portal/web/app/src/components/ApplicationSimpleCard.tsx
+++ b/consent/self-service-portal/web/app/src/components/ApplicationSimpleCard.tsx
@@ -113,12 +113,6 @@ function ApplicationSimpleCard({ client, clickable = true }: Props) {
       .filter(v => v)
   ).join(", ");
 
-  const expirationDateTime = new Date(newestConsent?.ExpirationDateTime);
-
-  const status =
-    (expirationDateTime.getFullYear() !== 1 &&
-      (expirationDateTime < new Date() ? "Expired" : "Active")) ||
-    "Active";
 
   return (
     <div
@@ -143,8 +137,6 @@ function ApplicationSimpleCard({ client, clickable = true }: Props) {
           </Avatar>
         )}
         <h3 className={classes.name}>{client.name}</h3>
-        <div style={{ flex: 1 }} />
-        <Chip type="active">{status}</Chip>
       </div>
       <div className={classes.content}>
         <div>


### PR DESCRIPTION
## Jira task - https://cloudentity.atlassian.net/browse/AUT-7676

## Release Notes Description (public)
Removed application status from consent self-service portal.
The motivation was that it always showed `Active` unless all consents expiration times were in past, which did not corresponded to status of consents. Additionally we have no special `Inactive` status for the application in which creating new consents is not possible.
<!--- DESCRIPTION USED IN THE RELEASE NOTES

Remove this comment and replace it with the description of your changes for an external audience. 
This description will be pulled into public release notes.

1. What changes are you introducing? Be clear and provide a detailed overview of your changes.
2. Why are you introducing the changes? Make the intent of the changes clear.
    - What do those changes mean for our end users?
    - Why should they care?
    - What is the context of your changes?

Additionally:

- If your changes are breaking changes, provide information on how the change affects our customers and what is required from them to be updated.
  If you think a migration guide would be useful, let TWs know in advance.
- If your changes deprecate an API, provide what is the alternative for our customers (if it exists). State clearly that an API became deprecated.
-->

## Implementation details (internal)

<!--- Describe technical implementation details for peer reviewers -->

## Information for QA

<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Screenshots (if appropriate):
