### PR TITLE
Additional Configuration Script Fix for Mac

### DIFF
--- a/scripts/additional_configuration.sh
+++ b/scripts/additional_configuration.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # prefix
-export PREFIX=${3,,}
+export PREFIX=$(echo $3 | tr [:upper:] [:lower:])
 
 configure_prefix() {
     local id=$1


### PR DESCRIPTION
Fix for 
```
./scripts/additional_configuration.sh: line 5: PREFIX=${3,,}: bad substitution
make: *** [run-obbr-local] Error 1
```
on mac os
