### PR TITLE
Bump crdb and acp + temporary enable RS256 for token endpoint signing alg

### DIFF
--- a/.env-local
+++ b/.env-local
@@ -14,7 +14,7 @@ ACP_BASE_URL=authorization.cloudentity.com:8443
 ACP_MTLS_URL=https://authorization.cloudentity.com:8443
 
 # acp version
-ACP_VERSION=2.8.1-81297aa
+ACP_VERSION=2.9.0-8e9a681
 
 # host where apps are deployed
 APP_HOST=localhost

--- a/data/imports/cdr.tmpl
+++ b/data/imports/cdr.tmpl
@@ -141,6 +141,10 @@ servers:
     - private_key_jwt
     - client_secret_post
     - tls_client_auth
+  token_endpoint_auth_signing_alg_values:
+    - RS256
+    - ES256
+    - PS256
   initialize: true
   cdr:
     brand_id:

--- a/docker-compose.acp.local.yaml
+++ b/docker-compose.acp.local.yaml
@@ -59,7 +59,7 @@ services:
 
   crdb:
     container_name: quickstart-crdb
-    image: cockroachdb/cockroach:v21.2.3
+    image: docker.cloudentity.io/cockroachdb/cockroach:v22.2.0
     restart: always
     ports:
       - 26258:26257


### PR DESCRIPTION
## Jira task - PUT_JIRA_LINK_HERE

## Implementation details (internal)

Bump crdb and acp
Temporary add RS256 as allowed signing alg fix for CDR. By default RS256 is not allowed for new CDR workspaces.
Enable CDR tests.

## Information for QA

<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Screenshots (if appropriate):
