### PR TITLE
AUT-8041 -  switch redis search to redis stack

### DIFF
--- a/docker-compose.acp.local.yaml
+++ b/docker-compose.acp.local.yaml
@@ -76,7 +76,7 @@ services:
       - ./mount/redis/redis.conf:/redis-stack.conf
     ports:
       - 6380:6379
-      - 8001:8001
+      - 8006:8001
 
   jaeger:
     container_name: jaeger

--- a/docker-compose.acp.local.yaml
+++ b/docker-compose.acp.local.yaml
@@ -8,8 +8,8 @@ services:
     networks:
       default:
         aliases:
-        - authorization.cloudentity.com
-        - test-docker
+          - authorization.cloudentity.com
+          - test-docker
     ports:
       - 8443:8443
     volumes:
@@ -70,13 +70,13 @@ services:
 
   redis:
     container_name: quickstart-redis
-    image: redislabs/redisearch:2.4.8
+    image: docker.cloudentity.io/redis/redis-stack:6.2.6-v0
     restart: on-failure
-    command: redis-server /usr/local/etc/redis/redis.conf --loadmodule /usr/lib/redis/modules/redisearch.so
     volumes:
-      - ./mount/redis/redis.conf:/usr/local/etc/redis/redis.conf
+      - ./mount/redis/redis.conf:/redis-stack.conf
     ports:
       - 6380:6379
+      - 8001:8001
 
   jaeger:
     container_name: jaeger


### PR DESCRIPTION
## Jira task - https://cloudentity.atlassian.net/browse/AUT-8041


## Release Notes Description (public)

<!--- DESCRIPTION USED IN THE RELEASE NOTES

Remove this comment and replace it with the description of your changes for an external audience. 
This description will be pulled into public release notes.

1. What changes are you introducing? Be clear and provide a detailed overview of your changes.
2. Why are you introducing the changes? Make the intent of the changes clear.
    - What do those changes mean for our end users?
    - Why should they care?
    - What is the context of your changes?

Additionally:

- If your changes are breaking changes, provide information on how the change affects our customers and what is required from them to be updated.
  If you think a migration guide would be useful, let TWs know in advance.
- If your changes deprecate an API, provide what is the alternative for our customers (if it exists). State clearly that an API became deprecated.
-->

## Implementation details (internal)

Switch local redis to redis stack to solve problems with redisearch crashing on m1 apple cpus.
Analogically to https://github.com/cloudentity/acp/pull/4265 
Tested locally on obuk and all turned on properly

## Information for QA

<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Screenshots (if appropriate):
