### PR TITLE
AUT-8047: Increase COMPOSE_HTTP_TIMEOUT

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         timeout(time: 1, unit: 'HOURS')
     }
     environment {
+        COMPOSE_HTTP_TIMEOUT = 120 
         VERIFY_TEST_RUNNER_TIMEOUT_MS = 80000
         SAAS_TENANT_ID = 'amfudxn6-qa-us-east-1-ob-quickstart'
         SAAS_CLIENT_ID = credentials('OPENBANKING_CONFIGURATION_CLIENT_ID')

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build-%:
 run-%-local:
 	./scripts/additional_configuration.sh $* "local" ${BRANCH_NAME}
 	cp -f .env-local .env
-	docker-compose -f docker-compose.acp.local.yaml up -d --no-build ${ACP_LOCAL_APPS}
+	COMPOSE_HTTP_TIMEOUT=120 docker-compose -f docker-compose.acp.local.yaml up -d --no-build ${ACP_LOCAL_APPS}
 	./scripts/wait.sh
 	docker-compose -f docker-compose.$*.yaml up --no-build -d
 	./scripts/wait.sh

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ run-%-local:
 	cp -f .env-local .env
 	COMPOSE_HTTP_TIMEOUT=120 docker-compose -f docker-compose.acp.local.yaml up -d --no-build ${ACP_LOCAL_APPS}
 	./scripts/wait.sh
-	docker-compose -f docker-compose.$*.yaml up --no-build -d
+	COMPOSE_HTTP_TIMEOUT=120 docker-compose -f docker-compose.$*.yaml up --no-build -d
 	./scripts/wait.sh
 
 # obuk, obbr, cdr, fdx

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ build-%:
 run-%-local:
 	./scripts/additional_configuration.sh $* "local" ${BRANCH_NAME}
 	cp -f .env-local .env
-	COMPOSE_HTTP_TIMEOUT=120 docker-compose -f docker-compose.acp.local.yaml up -d --no-build ${ACP_LOCAL_APPS}
+	docker-compose -f docker-compose.acp.local.yaml up -d --no-build ${ACP_LOCAL_APPS}
 	./scripts/wait.sh
-	COMPOSE_HTTP_TIMEOUT=120 docker-compose -f docker-compose.$*.yaml up --no-build -d
+	docker-compose -f docker-compose.$*.yaml up --no-build -d
 	./scripts/wait.sh
 
 # obuk, obbr, cdr, fdx


### PR DESCRIPTION
## Jira task - [PUT_JIRA_LINK_HERE](https://cloudentity.atlassian.net/browse/AUT-8047)

## BREAKING CHANGE - remove this line if your code doesn't introduce a breaking change

## Release Notes Description (public)

<!--- DESCRIPTION USED IN THE RELEASE NOTES

Remove this comment and replace it with the description of your changes for an external audience. 
This description will be pulled into public release notes.

1. What changes are you introducing? Be clear and provide a detailed overview of your changes.
2. Why are you introducing the changes? Make the intent of the changes clear.
    - What do those changes mean for our end users?
    - Why should they care?
    - What is the context of your changes?

Additionally:

- If your changes are breaking changes, provide information on how the change affects our customers and what is required from them to be updated.
  If you think a migration guide would be useful, let TWs know in advance.
- If your changes deprecate an API, provide what is the alternative for our customers (if it exists). State clearly that an API became deprecated.
-->

## Implementation details (internal)
Timeout increased to make pipeline more stable. Probably in situation where we need to download new containers and CRDB starts slower the ACP container is restarted (+30s to startup time) and we reach standard 60s timeout. After the change startup time is increased to 120s.
<!--- Describe technical implementation details for peer reviewers -->

## Information for QA

<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Screenshots (if appropriate):
