### PR TITLE
feature/AUT-8702-fix-fdx-saas-tests

### DIFF
--- a/tests/cypress/pages/fdx-tpp/FdxTppAuthenticatedPage.ts
+++ b/tests/cypress/pages/fdx-tpp/FdxTppAuthenticatedPage.ts
@@ -29,7 +29,9 @@ export class FdxTppAuthenticatedPage {
       expect(text).to.match(/\"access_token\"\: \"[a-zA-Z0-9_.-]+\"/);
       expect(text).to.match(/\"id_token\"\: \"[a-zA-Z0-9_.-]+\"/);
       expect(text).to.contain('"token_type": "bearer"');
-      expect(text).to.contain('"scope": "openid READ_CONSENTS UPDATE_CONSENTS"');
+      expect(text).to.match(/\"scope\"\: +[a-zA-Z_ "]+openid+[a-zA-Z_ ]*\"/);
+      expect(text).to.match(/\"scope\"\: +[a-zA-Z_ "]+READ_CONSENTS+[a-zA-Z_ ]*\"/);
+      expect(text).to.match(/\"scope\"\: +[a-zA-Z_ "]+UPDATE_CONSENTS+[a-zA-Z_ ]*\"/);
       expect(text).to.match(/\"expires_in\"\: [0-9]+\,/);
       expect(text).to.match(/\"grant_id\"\: \"[a-zA-Z0-9]+\"/);
     });


### PR DESCRIPTION
## Jira task - [AUT-8702](https://cloudentity.atlassian.net/browse/AUT-8702)

## Implementation details (internal)

Fix for failing FDX SaaS test:
- Updated `assertThatTokenResponseFieldIsNotEmpty` method to verify displayed scopes in random order

## Information for QA

<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->

- [ ] Is QA testing required?
- [x] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

N/A



[AUT-8702]: https://cloudentity.atlassian.net/browse/AUT-8702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ