### PR TITLE
ACP skip certificate validation when calling external services

### DIFF
--- a/docker-compose.acp.local.yaml
+++ b/docker-compose.acp.local.yaml
@@ -36,6 +36,7 @@ services:
       - SERVER_DISABLE_CSRF=true
       - SERVER_DO_NOT_PRINT_AUDIT_LOGS_FOR_STATIC_FILES=true
       - CLIENT_ROOT_CA=/acp_ca.pem
+      - CLIENT_INSECURE_SKIP_VERIFY=true
       - REDIS_ENABLED=true
       - REDIS_ADDRESS=redis:6379
       - OTEL_JAEGER_AGENT_HOST=jaeger


### PR DESCRIPTION
## Jira task - PUT_JIRA_LINK_HERE

## Release Notes Description (public)

## Implementation details (internal)

ACP cannot call data mock recipient as the certificate has expired.
As we are no longer actively maintaining this repository but still some people are using it mostly for demo purposes, I'm switching ACP http client to not verify certificate when calling external services.

```
{"error":"failed to get data recipients: Get \"https://mock-register:7000/cdr-register/v1/banking/data-recipients\": GET https://mock-register:7000/cdr-register/v1/banking/data-recipients giving up after 3 attempt(s): Get \"https://mock-register:7000/cdr-register/v1/banking/data-recipients\": tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2023-07-17T15:15:08Z is after 2023-06-15T05:36:38Z","level":"warning","msg":"failed to process cdr register","time":"2023-07-17T15:15:08Z","traceID":"184614a0f4efa24fa1b1e3a9cbd38247"}
```

## Information for QA

<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Screenshots (if appropriate):
