### PR TITLE
[AUT-9768] Init generic openbanking spec based on fapi 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build:
 build-%:
 	docker-compose ${ALL_DOCKER_COMPOSES} build $*
 
-# obuk, obbr, cdr, fdx
+# obuk, obbr, cdr, fdx, generic
 run-%-local:
 	./scripts/additional_configuration.sh $* "local" ${BRANCH_NAME}
 	cp -f .env-local .env

--- a/apps/bank/generic_get_accounts_handler.go
+++ b/apps/bank/generic_get_accounts_handler.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-
-	// obbrAccountModels "github.com/cloudentity/openbanking-quickstart/generated/obbr/accounts/models"
 	"github.com/gin-gonic/gin"
 
 	oauth2Models "github.com/cloudentity/acp-client-go/clients/oauth2/models"
@@ -35,16 +33,6 @@ func (h *GenericGetAccountsHandler) BuildResponse(c *gin.Context, data BankUserD
 }
 
 func (h *GenericGetAccountsHandler) Validate(c *gin.Context) *Error {
-	// scopes := strings.Split(h.introspectionResponse.Scope, " ")
-	// if !has(scopes, "consents") {
-	// 	return ErrForbidden.WithMessage("token has no consents scope granted")
-	// }
-
-	// grantedPermissions := h.introspectionResponse.Permissions
-	// if !has(GenericPermsToStringSlice(grantedPermissions), "ACCOUNTS_READ") {
-	// 	return ErrForbidden.WithMessage("ACCOUNTS_READ permission has not been granted")
-	// }
-
 	return nil
 }
 
@@ -53,12 +41,5 @@ func (h *GenericGetAccountsHandler) GetUserIdentifier(c *gin.Context) string {
 }
 
 func (h *GenericGetAccountsHandler) Filter(c *gin.Context, data BankUserData) BankUserData {
-	var ret BankUserData
-	for _, account := range data.GenericAccounts {
-		// if has(h.introspectionResponse.AccountIDs, *account.AccountID) {
-		ret.GenericAccounts = append(ret.GenericAccounts, account)
-		// }
-	}
-
-	return ret
+	return data
 }

--- a/apps/bank/generic_get_accounts_handler.go
+++ b/apps/bank/generic_get_accounts_handler.go
@@ -6,24 +6,8 @@ import (
 	"github.com/gin-gonic/gin"
 
 	oauth2Models "github.com/cloudentity/acp-client-go/clients/oauth2/models"
-	obbrAccountModels "github.com/cloudentity/openbanking-quickstart/generated/obbr/accounts/models"
 )
 
-// swagger:route GET /accounts bank br getAccountsRequest
-//
-// get accounts
-//
-// Security:
-//
-//	defaultcc: accounts
-//
-// Responses:
-//
-//	  200: ResponseAccountList
-//		 400: OpenbankingBrasilResponseError
-//	  403: OpenbankingBrasilResponseError
-//	  404: OpenbankingBrasilResponseError
-//	  500: OpenbankingBrasilResponseError
 type GenericGetAccountsHandler struct {
 	*Server
 	introspectionResponse *oauth2Models.IntrospectResponse
@@ -69,22 +53,12 @@ func (h *GenericGetAccountsHandler) GetUserIdentifier(c *gin.Context) string {
 }
 
 func (h *GenericGetAccountsHandler) Filter(c *gin.Context, data BankUserData) BankUserData {
-	var (
-		filteredAccounts []obbrAccountModels.AccountData
-		// requestedAccountType = c.Query("accountType")
-	)
-
-	// for _, account := range data.GenericAccounts {
-	// 	if !has(h.introspectionResponse.AccountIDs, *account.AccountID) {
-	// 		continue
-	// 	}
-	// 	if requestedAccountType != "" && string(*account.Type) != requestedAccountType {
-	// 		continue
-	// 	}
-	// 	filteredAccounts = append(filteredAccounts, account)
-	// }
-
-	return BankUserData{
-		GenericAccounts: filteredAccounts,
+	var ret BankUserData
+	for _, account := range data.GenericAccounts {
+		// if has(h.introspectionResponse.AccountIDs, *account.AccountID) {
+		ret.GenericAccounts = append(ret.GenericAccounts, account)
+		// }
 	}
+
+	return ret
 }

--- a/apps/bank/generic_get_accounts_handler.go
+++ b/apps/bank/generic_get_accounts_handler.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+
+	// obbrAccountModels "github.com/cloudentity/openbanking-quickstart/generated/obbr/accounts/models"
+	"github.com/gin-gonic/gin"
+
+	oauth2Models "github.com/cloudentity/acp-client-go/clients/oauth2/models"
+	obbrAccountModels "github.com/cloudentity/openbanking-quickstart/generated/obbr/accounts/models"
+)
+
+// swagger:route GET /accounts bank br getAccountsRequest
+//
+// get accounts
+//
+// Security:
+//
+//	defaultcc: accounts
+//
+// Responses:
+//
+//	  200: ResponseAccountList
+//		 400: OpenbankingBrasilResponseError
+//	  403: OpenbankingBrasilResponseError
+//	  404: OpenbankingBrasilResponseError
+//	  500: OpenbankingBrasilResponseError
+type GenericGetAccountsHandler struct {
+	*Server
+	introspectionResponse *oauth2Models.IntrospectResponse
+}
+
+func NewGenericGetAccountsHandler(server *Server) GetEndpointLogic {
+	return &GenericGetAccountsHandler{Server: server}
+}
+
+func (h *GenericGetAccountsHandler) SetIntrospectionResponse(c *gin.Context) *Error {
+	var err error
+	if h.introspectionResponse, err = h.GenericIntrospectAccountsToken(c); err != nil {
+		return ErrBadRequest.WithMessage("failed to introspect token").WithError(err)
+	}
+	return nil
+}
+
+func (h *GenericGetAccountsHandler) MapError(c *gin.Context, err *Error) (code int, resp interface{}) {
+	code, resp = GenericMapError(c, err)
+	return
+}
+
+func (h *GenericGetAccountsHandler) BuildResponse(c *gin.Context, data BankUserData) (interface{}, *Error) {
+	return NewGenericAccountsResponse(data.GenericAccounts), nil
+}
+
+func (h *GenericGetAccountsHandler) Validate(c *gin.Context) *Error {
+	// scopes := strings.Split(h.introspectionResponse.Scope, " ")
+	// if !has(scopes, "consents") {
+	// 	return ErrForbidden.WithMessage("token has no consents scope granted")
+	// }
+
+	// grantedPermissions := h.introspectionResponse.Permissions
+	// if !has(GenericPermsToStringSlice(grantedPermissions), "ACCOUNTS_READ") {
+	// 	return ErrForbidden.WithMessage("ACCOUNTS_READ permission has not been granted")
+	// }
+
+	return nil
+}
+
+func (h *GenericGetAccountsHandler) GetUserIdentifier(c *gin.Context) string {
+	return h.introspectionResponse.Sub
+}
+
+func (h *GenericGetAccountsHandler) Filter(c *gin.Context, data BankUserData) BankUserData {
+	var (
+		filteredAccounts []obbrAccountModels.AccountData
+		// requestedAccountType = c.Query("accountType")
+	)
+
+	// for _, account := range data.GenericAccounts {
+	// 	if !has(h.introspectionResponse.AccountIDs, *account.AccountID) {
+	// 		continue
+	// 	}
+	// 	if requestedAccountType != "" && string(*account.Type) != requestedAccountType {
+	// 		continue
+	// 	}
+	// 	filteredAccounts = append(filteredAccounts, account)
+	// }
+
+	return BankUserData{
+		GenericAccounts: filteredAccounts,
+	}
+}

--- a/apps/bank/generic_get_accounts_internal_handler.go
+++ b/apps/bank/generic_get_accounts_internal_handler.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	obbrAccountModels "github.com/cloudentity/openbanking-quickstart/generated/obbr/accounts/models"
+	"github.com/cloudentity/openbanking-quickstart/generated/obbr/consents/models"
+	"github.com/gin-gonic/gin"
+)
+
+// swagger:route GET /internal/accounts bank generic getInternalAccountsRequest
+//
+// get all accounts for user
+//
+// Security:
+//
+//	defaultcc: accounts
+//
+// Responses:
+//
+//	200: ResponseAccountList
+//	404: OpenbankingBrasilResponseError
+type GenericGetAccountsInternalHandler struct {
+	*Server
+}
+
+func NewGenericGetAccountsInternalHandler(server *Server) GetEndpointLogic {
+	return &GenericGetAccountsInternalHandler{Server: server}
+}
+
+func (h *GenericGetAccountsInternalHandler) SetIntrospectionResponse(c *gin.Context) *Error {
+	return nil
+}
+
+func (h *GenericGetAccountsInternalHandler) MapError(c *gin.Context, err *Error) (code int, resp interface{}) {
+	code, resp = GenericMapError(c, err)
+	return
+}
+
+func (h *GenericGetAccountsInternalHandler) BuildResponse(c *gin.Context, data BankUserData) (interface{}, *Error) {
+	return NewGenericAccountsResponse(data.GenericAccounts), nil
+}
+
+func (h *GenericGetAccountsInternalHandler) Validate(c *gin.Context) *Error {
+	return nil
+}
+
+func (h *GenericGetAccountsInternalHandler) GetUserIdentifier(c *gin.Context) string {
+	return c.Query("id")
+}
+
+func (h *GenericGetAccountsInternalHandler) Filter(c *gin.Context, data BankUserData) BankUserData {
+	return data
+}
+
+func GenericMapError(c *gin.Context, err *Error) (code int, resp interface{}) {
+	code, resp = err.Code, models.OpenbankingBrasilConsentV2ResponseError{
+		Errors: []*models.OpenbankingBrasilConsentV2Error{
+			{
+				Detail: err.Message,
+			},
+		},
+	}
+	return
+}
+
+func NewGenericAccountsResponse(accounts []obbrAccountModels.AccountData) obbrAccountModels.ResponseAccountList {
+	accountPointers := []*obbrAccountModels.AccountData{}
+	for _, account := range accounts {
+		a := account
+		accountPointers = append(accountPointers, &a)
+	}
+
+	return obbrAccountModels.ResponseAccountList{
+		Data: accountPointers,
+	}
+}

--- a/apps/bank/generic_get_accounts_internal_handler.go
+++ b/apps/bank/generic_get_accounts_internal_handler.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	obbrAccountModels "github.com/cloudentity/openbanking-quickstart/generated/obbr/accounts/models"
-	"github.com/cloudentity/openbanking-quickstart/generated/obbr/consents/models"
 	"github.com/gin-gonic/gin"
 )
 
@@ -51,25 +49,7 @@ func (h *GenericGetAccountsInternalHandler) Filter(c *gin.Context, data BankUser
 	return data
 }
 
-func GenericMapError(c *gin.Context, err *Error) (code int, resp interface{}) {
-	code, resp = err.Code, models.OpenbankingBrasilConsentV2ResponseError{
-		Errors: []*models.OpenbankingBrasilConsentV2Error{
-			{
-				Detail: err.Message,
-			},
-		},
-	}
+func GenericCDRMapError(c *gin.Context, err *Error) (code int, resp interface{}) {
+	code, resp = 400, nil
 	return
-}
-
-func NewGenericAccountsResponse(accounts []obbrAccountModels.AccountData) obbrAccountModels.ResponseAccountList {
-	accountPointers := []*obbrAccountModels.AccountData{}
-	for _, account := range accounts {
-		a := account
-		accountPointers = append(accountPointers, &a)
-	}
-
-	return obbrAccountModels.ResponseAccountList{
-		Data: accountPointers,
-	}
 }

--- a/apps/bank/generic_get_accounts_internal_handler.go
+++ b/apps/bank/generic_get_accounts_internal_handler.go
@@ -4,18 +4,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// swagger:route GET /internal/accounts bank generic getInternalAccountsRequest
-//
-// get all accounts for user
-//
-// Security:
-//
-//	defaultcc: accounts
-//
-// Responses:
-//
-//	200: ResponseAccountList
-//	404: OpenbankingBrasilResponseError
 type GenericGetAccountsInternalHandler struct {
 	*Server
 }

--- a/apps/bank/generic_get_balances_handler.go
+++ b/apps/bank/generic_get_balances_handler.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+
+	oauth2Models "github.com/cloudentity/acp-client-go/clients/oauth2/models"
+)
+
+type GenericGetBalancesHandler struct {
+	*Server
+	introspectionResponse *oauth2Models.IntrospectResponse
+}
+
+func NewGenericGetBalancesHandler(server *Server) GetEndpointLogic {
+	return &GenericGetBalancesHandler{Server: server}
+}
+
+func (h *GenericGetBalancesHandler) SetIntrospectionResponse(c *gin.Context) *Error {
+	var err error
+	if h.introspectionResponse, err = h.GenericIntrospectAccountsToken(c); err != nil {
+		return ErrBadRequest.WithMessage("failed to introspect token")
+	}
+	return nil
+}
+
+func (h *GenericGetBalancesHandler) MapError(c *gin.Context, err *Error) (code int, resp interface{}) {
+	code, resp = GenericMapError(c, err)
+	return
+}
+
+func (h *GenericGetBalancesHandler) BuildResponse(c *gin.Context, data BankUserData) (interface{}, *Error) {
+	return NewGenericBalancesResponse(data.GenericBalances), nil
+}
+
+func (h *GenericGetBalancesHandler) Validate(c *gin.Context) *Error {
+	return nil
+}
+
+func (h *GenericGetBalancesHandler) GetUserIdentifier(c *gin.Context) string {
+	return GetGenericUserIdentifierClaimFromIntrospectionResponse(h.Config, h.introspectionResponse)
+}
+
+func (h *GenericGetBalancesHandler) Filter(c *gin.Context, data BankUserData) BankUserData {
+	return data
+}

--- a/apps/bank/generic_get_transactions_handler.go
+++ b/apps/bank/generic_get_transactions_handler.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+
+	oauth2Models "github.com/cloudentity/acp-client-go/clients/oauth2/models"
+)
+
+type GenericGetTransactionsHandler struct {
+	*Server
+	introspectionResponse *oauth2Models.IntrospectResponse
+}
+
+func NewGenericGetTransactionsHandler(server *Server) GetEndpointLogic {
+	return &GenericGetTransactionsHandler{Server: server}
+}
+
+func (h *GenericGetTransactionsHandler) SetIntrospectionResponse(c *gin.Context) *Error {
+	var err error
+	if h.introspectionResponse, err = h.GenericIntrospectAccountsToken(c); err != nil {
+		return ErrBadRequest.WithMessage("failed to introspect token")
+	}
+	return nil
+}
+
+func (h *GenericGetTransactionsHandler) MapError(c *gin.Context, err *Error) (code int, resp interface{}) {
+	code, resp = GenericMapError(c, err)
+	return
+}
+
+func (h *GenericGetTransactionsHandler) BuildResponse(c *gin.Context, data BankUserData) (interface{}, *Error) {
+	return NewGenericTransactionsResponse(data.GenericTransactions), nil
+}
+
+func (h *GenericGetTransactionsHandler) Validate(c *gin.Context) *Error {
+	// scopes := strings.Split(h.introspectionResponse.Scope, " ")
+	// if !has(scopes, "bank:transactions:read") {
+	// 	return ErrForbidden.WithMessage("token has no bank:transactions:read scope granted")
+	// }
+	return nil
+}
+
+func (h *GenericGetTransactionsHandler) GetUserIdentifier(c *gin.Context) string {
+	return GetGenericUserIdentifierClaimFromIntrospectionResponse(h.Config, h.introspectionResponse)
+}
+
+func (h *GenericGetTransactionsHandler) Filter(c *gin.Context, data BankUserData) BankUserData {
+	var (
+		ret       BankUserData
+		accountID = c.Param("accountId")
+	)
+
+	for _, transaction := range data.GenericTransactions {
+		if *transaction.AccountID == accountID {
+			// if has(h.introspectionResponse.AccountIDs, *transaction.AccountID) && *transaction.AccountID == accountID {
+			ret.GenericTransactions = append(ret.GenericTransactions, transaction)
+		}
+	}
+	return ret
+}

--- a/apps/bank/generic_get_transactions_handler.go
+++ b/apps/bank/generic_get_transactions_handler.go
@@ -33,10 +33,6 @@ func (h *GenericGetTransactionsHandler) BuildResponse(c *gin.Context, data BankU
 }
 
 func (h *GenericGetTransactionsHandler) Validate(c *gin.Context) *Error {
-	// scopes := strings.Split(h.introspectionResponse.Scope, " ")
-	// if !has(scopes, "bank:transactions:read") {
-	// 	return ErrForbidden.WithMessage("token has no bank:transactions:read scope granted")
-	// }
 	return nil
 }
 
@@ -52,7 +48,6 @@ func (h *GenericGetTransactionsHandler) Filter(c *gin.Context, data BankUserData
 
 	for _, transaction := range data.GenericTransactions {
 		if *transaction.AccountID == accountID {
-			// if has(h.introspectionResponse.AccountIDs, *transaction.AccountID) && *transaction.AccountID == accountID {
 			ret.GenericTransactions = append(ret.GenericTransactions, transaction)
 		}
 	}

--- a/apps/bank/generic_model.go
+++ b/apps/bank/generic_model.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"github.com/cloudentity/openbanking-quickstart/generated/cdr/models"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+
+	oauth2Models "github.com/cloudentity/acp-client-go/clients/oauth2/models"
+)
+
+func NewGenericTransactionsResponse(transactions []models.BankingTransaction) interface{} {
+	resp := models.ResponseBankingTransactionList{
+		Data: &models.Data3{
+			Transactions: []*models.BankingTransaction{},
+		},
+	}
+	for _, transaction := range transactions {
+		trans := transaction
+		resp.Data.Transactions = append(resp.Data.Transactions, &trans)
+	}
+	return resp
+}
+
+func NewGenericBalancesResponse(balances []models.BankingBalance) interface{} {
+	resp := models.ResponseBankingAccountsBalanceList{
+		Data: &models.Data4{
+			Balances: []*models.BankingBalance{},
+		},
+	}
+	for _, balance := range balances {
+		bal := balance
+		resp.Data.Balances = append(resp.Data.Balances, &bal)
+	}
+	return resp
+}
+
+func GetGenericUserIdentifierClaimFromIntrospectionResponse(config Config, introspectResponse *oauth2Models.IntrospectResponse) string {
+	if claim, ok := introspectResponse.Ext[config.UserIdentifierClaim].(string); ok {
+		return claim
+	}
+
+	logrus.Info("No user identifier claim configured. Falling back to sub")
+	return introspectResponse.Sub
+}
+
+func NewGenericAccountsResponse(accounts []models.BankingAccount) interface{} {
+	resp := models.ResponseBankingAccountList{
+		Data: &models.Data2{
+			Accounts: []*models.BankingAccount{},
+		},
+	}
+	for _, account := range accounts {
+		acc := account
+		resp.Data.Accounts = append(resp.Data.Accounts, &acc)
+	}
+	return resp
+}
+
+func GenericMapError(c *gin.Context, err *Error) (code int, resp interface{}) {
+	code, resp = 400, nil
+	return
+}

--- a/apps/bank/introspect.go
+++ b/apps/bank/introspect.go
@@ -9,9 +9,12 @@ import (
 
 	cdr "github.com/cloudentity/acp-client-go/clients/cdr/client/c_d_r"
 	fdx "github.com/cloudentity/acp-client-go/clients/fdx/client/f_d_x"
+	"github.com/cloudentity/acp-client-go/clients/oauth2/client/oauth2"
 	obbr "github.com/cloudentity/acp-client-go/clients/obbr/client/o_b_b_r"
-	"github.com/cloudentity/acp-client-go/clients/obbr/models"
+	obbrModels "github.com/cloudentity/acp-client-go/clients/obbr/models"
 	obuk "github.com/cloudentity/acp-client-go/clients/obuk/client/o_b_u_k"
+
+	oauth2Models "github.com/cloudentity/acp-client-go/clients/oauth2/models"
 )
 
 func (s *Server) OBUKIntrospectAccountsToken(c *gin.Context) (*obuk.OpenbankingAccountAccessConsentIntrospectOKBody, error) {
@@ -59,7 +62,7 @@ func (s *Server) OBUKIntrospectPaymentsToken(c *gin.Context) (*obuk.OpenbankingD
 	return introspectionResponse.Payload, nil
 }
 
-func (s *Server) OBBRIntrospectAccountsToken(c *gin.Context) (*models.IntrospectOBBRDataAccessConsentResponse, error) {
+func (s *Server) OBBRIntrospectAccountsToken(c *gin.Context) (*obbrModels.IntrospectOBBRDataAccessConsentResponse, error) {
 	var (
 		introspectionResponse *obbr.ObbrDataAccessConsentIntrospectOK
 		err                   error
@@ -83,7 +86,7 @@ func (s *Server) OBBRIntrospectAccountsToken(c *gin.Context) (*models.Introspect
 	return introspectionResponse.Payload, nil
 }
 
-func (s *Server) OBBRIntrospectPaymentsToken(c *gin.Context) (*models.IntrospectOBBRPaymentConsentResponse, error) {
+func (s *Server) OBBRIntrospectPaymentsToken(c *gin.Context) (*obbrModels.IntrospectOBBRPaymentConsentResponse, error) {
 	var (
 		introspectionResponse *obbr.ObbrPaymentConsentIntrospectOK
 		err                   error
@@ -151,4 +154,28 @@ func (s *Server) FDXIntrospectAccountsToken(c *gin.Context) (*fdx.FdxConsentIntr
 	}
 
 	return introspectResponse.Payload, nil
+}
+
+func (s *Server) GenericIntrospectAccountsToken(c *gin.Context) (*oauth2Models.IntrospectResponse, error) {
+	var (
+		introspectionResponse *oauth2.IntrospectOK
+		err                   error
+	)
+
+	token := c.GetHeader("Authorization")
+	token = strings.ReplaceAll(token, "Bearer ", "")
+
+	if introspectionResponse, err = s.Client.Oauth2.Oauth2.Introspect(
+		oauth2.NewIntrospectParamsWithContext(c).
+			WithToken(&token),
+		nil,
+	); err != nil {
+		return nil, err
+	}
+
+	if !introspectionResponse.Payload.Active {
+		return nil, errors.New("access token is not active")
+	}
+
+	return introspectionResponse.Payload, nil
 }

--- a/apps/bank/main.go
+++ b/apps/bank/main.go
@@ -144,8 +144,10 @@ func (s *Server) Start() error {
 		r.GET("/accounts/:accountId/transactions", s.Get(NewFDXGetTransactionsHandler))
 
 	case Generic:
-		r.GET("/accounts/v1/accounts", s.Get(NewGenericGetAccountsHandler)) // TODOX change path
-		r.GET("/internal/accounts", s.Get(NewGenericGetAccountsInternalHandler))
+		r.POST("/internal/accounts", s.Get(NewGenericGetAccountsInternalHandler))
+		r.GET("/banking/accounts", s.Get(NewGenericGetAccountsHandler))
+		r.GET("/banking/accounts/:accountId/transactions", s.Get(NewGenericGetTransactionsHandler))
+		r.GET("/banking/accounts/balances", s.Get(NewGenericGetBalancesHandler))
 
 	default:
 		return fmt.Errorf("unsupported spec %s", s.Config.Spec)

--- a/apps/bank/main.go
+++ b/apps/bank/main.go
@@ -17,10 +17,11 @@ import (
 type Spec string
 
 const (
-	OBUK Spec = "obuk"
-	OBBR Spec = "obbr"
-	CDR  Spec = "cdr"
-	FDX  Spec = "fdx"
+	OBUK    Spec = "obuk"
+	OBBR    Spec = "obbr"
+	CDR     Spec = "cdr"
+	FDX     Spec = "fdx"
+	Generic Spec = "generic"
 )
 
 type Config struct {
@@ -37,11 +38,11 @@ type Config struct {
 	SeedFilePath        string
 }
 
-func (c *Config) ClientConfig() acpclient.Config {
+func (c *Config) ClientConfig(scopes []string) acpclient.Config {
 	return acpclient.Config{
 		ClientID:  c.ClientID,
 		IssuerURL: c.IssuerURL,
-		Scopes:    []string{"introspect_openbanking_tokens"},
+		Scopes:    scopes,
 		Timeout:   c.Timeout,
 		CertFile:  c.CertFile,
 		KeyFile:   c.KeyFile,
@@ -63,6 +64,10 @@ func LoadConfig() (config Config, err error) {
 		config.SeedFilePath = fmt.Sprintf("data/%s-data.json", CDR)
 	case FDX:
 		config.SeedFilePath = fmt.Sprintf("data/%s-data.json", FDX)
+	case Generic:
+		config.SeedFilePath = fmt.Sprintf("data/%s-data.json", Generic)
+	default:
+		return config, fmt.Errorf("unknown spec: %s", config.Spec)
 	}
 
 	if config.GINMODE == "debug" {
@@ -88,8 +93,15 @@ func NewServer() (Server, error) {
 		return server, errors.Wrapf(err, "failed to load config")
 	}
 
-	if server.Client, err = acpclient.New(server.Config.ClientConfig()); err != nil {
-		return server, errors.Wrapf(err, "failed to init acp client")
+	switch server.Config.Spec {
+	case Generic:
+		if server.Client, err = acpclient.New(server.Config.ClientConfig([]string{"introspect_tokens"})); err != nil {
+			return server, errors.Wrapf(err, "failed to init acp client")
+		}
+	default:
+		if server.Client, err = acpclient.New(server.Config.ClientConfig([]string{"introspect_openbanking_tokens"})); err != nil {
+			return server, errors.Wrapf(err, "failed to init acp client")
+		}
 	}
 
 	if server.Storage, err = NewUserRepo(server.Config.SeedFilePath); err != nil {
@@ -130,6 +142,10 @@ func (s *Server) Start() error {
 		r.GET("/internal/accounts", s.Get(NewFDXGetAccountsInternalHandler))
 		r.GET("/accounts/:accountId", s.Get(NewFDXGetBalancesHandler))
 		r.GET("/accounts/:accountId/transactions", s.Get(NewFDXGetTransactionsHandler))
+
+	case Generic:
+		r.GET("/accounts/v1/accounts", s.Get(NewGenericGetAccountsHandler)) // TODOX change path
+		r.GET("/internal/accounts", s.Get(NewGenericGetAccountsInternalHandler))
 
 	default:
 		return fmt.Errorf("unsupported spec %s", s.Config.Spec)

--- a/apps/bank/repo.go
+++ b/apps/bank/repo.go
@@ -35,7 +35,9 @@ type BankUserData struct {
 	FDXTransactions fdxAccountModels.Transactionsentity         `json:"fdx_transactions"`
 	FDXPayments     []fdxAccountModels.Paymententity            `json:"fdx_payments"`
 
-	GenericAccounts []obbrAccountModels.AccountData `json:"generic_accounts"`
+	GenericAccounts     []cdrAccountModels.BankingAccount     `json:"generic_accounts"`
+	GenericBalances     []cdrAccountModels.BankingBalance     `json:"generic_balances"`
+	GenericTransactions []cdrAccountModels.BankingTransaction `json:"generic_transactions"`
 }
 
 type AccountData struct {

--- a/apps/bank/repo.go
+++ b/apps/bank/repo.go
@@ -34,6 +34,8 @@ type BankUserData struct {
 	FDXBalances     []fdxAccountModels.AccountWithDetailsentity `json:"fdx_balances"`
 	FDXTransactions fdxAccountModels.Transactionsentity         `json:"fdx_transactions"`
 	FDXPayments     []fdxAccountModels.Paymententity            `json:"fdx_payments"`
+
+	GenericAccounts []obbrAccountModels.AccountData `json:"generic_accounts"`
 }
 
 type AccountData struct {

--- a/apps/configuration/templates.go
+++ b/apps/configuration/templates.go
@@ -99,7 +99,7 @@ func (t Templates) Merge() (YamlFile, error) {
 		}
 	}
 
-	logrus.Debugf("final yaml file: \n %s", yamlFile)
+	logrus.WithField("body", yamlFile).Debugf("import configuration")
 
 	return yamlFile, nil
 }

--- a/apps/financroo-tpp/clients.go
+++ b/apps/financroo-tpp/clients.go
@@ -392,3 +392,68 @@ func (c *CDRConsentClient) CreatePaymentConsent(ctx *gin.Context, req CreatePaym
 func (c *CDRConsentClient) Sign([]byte) (string, error) {
 	return "", nil
 }
+
+type GenericBankClient struct{}
+
+func NewGenericBankClient(config Config) (BankClient, error) {
+	return &GenericBankClient{}, nil
+}
+
+var _ BankClient = &GenericBankClient{}
+
+func (c *GenericBankClient) GetAccounts(ctx *gin.Context, accessToken string, bank ConnectedBank) ([]Account, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *GenericBankClient) GetTransactions(ctx *gin.Context, accessToken string, bank ConnectedBank) ([]Transaction, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *GenericBankClient) GetBalances(ctx *gin.Context, accessToken string, bank ConnectedBank) ([]Balance, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *GenericBankClient) CreatePayment(ctx *gin.Context, data interface{}, accessToken string) (PaymentCreated, error) {
+	return PaymentCreated{}, errors.New("not implemented")
+}
+
+type GenericConsentClient struct {
+}
+
+var _ ConsentClient = &GenericConsentClient{}
+
+func NewGenericConsentClient(publicClient, clientCredentialsClient acpclient.Client, _ Signer) ConsentClient {
+	return &GenericConsentClient{}
+}
+
+func (c *GenericConsentClient) CreateConsentExplicitly() bool {
+	return false
+}
+
+func (c *GenericConsentClient) UsePAR() bool {
+	return true
+}
+
+func (c *GenericConsentClient) DoPAR(ctx *gin.Context) (string, acpclient.CSRF, error) {
+	return "", acpclient.CSRF{}, errors.New("not implemented")
+}
+
+func (c *GenericConsentClient) CreateAccountConsent(ctx *gin.Context) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (c *GenericConsentClient) DoRequestObjectEncryption() bool {
+	return false
+}
+
+func (c *GenericConsentClient) GetPaymentConsent(ctx *gin.Context, consentID string) (interface{}, error) {
+	return "", errors.New("not implemented")
+}
+
+func (c *GenericConsentClient) CreatePaymentConsent(ctx *gin.Context, req CreatePaymentRequest) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (c *GenericConsentClient) Sign([]byte) (string, error) {
+	return "", errors.New("not implemented")
+}

--- a/apps/financroo-tpp/clients.go
+++ b/apps/financroo-tpp/clients.go
@@ -191,6 +191,10 @@ func NewAcpClient(cfg Config, redirect string) (acpclient.Client, error) {
 		config.AuthMethod = acpclient.TLSClientAuthnMethod
 	}
 
+	if cfg.Spec == GENERIC {
+		config.SkipClientCredentialsAuthn = true
+	}
+
 	if client, err = acpclient.New(config); err != nil {
 		return client, err
 	}

--- a/apps/financroo-tpp/clients.go
+++ b/apps/financroo-tpp/clients.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	cdrBank "github.com/cloudentity/openbanking-quickstart/generated/cdr/client"
-	"github.com/cloudentity/openbanking-quickstart/generated/cdr/client/banking"
 	cdrModels "github.com/cloudentity/openbanking-quickstart/generated/cdr/client/banking"
 	fdxBank "github.com/cloudentity/openbanking-quickstart/generated/fdx/client"
 	obbrPayments "github.com/cloudentity/openbanking-quickstart/generated/obbr/payments/client"
@@ -470,7 +469,7 @@ func (c *GenericBankClient) GetAccounts(ctx *gin.Context, accessToken string, ba
 
 func (c *GenericBankClient) GetTransactions(ctx *gin.Context, accessToken string, bank ConnectedBank) ([]Transaction, error) {
 	var (
-		resp             *banking.GetTransactionsOK
+		resp             *cdrModels.GetTransactionsOK
 		accounts         []Account
 		transactionsData []Transaction
 		err              error
@@ -482,7 +481,7 @@ func (c *GenericBankClient) GetTransactions(ctx *gin.Context, accessToken string
 
 	for _, account := range accounts {
 		if resp, err = c.Banking.Banking.GetTransactions(
-			banking.NewGetTransactionsParams().
+			cdrModels.NewGetTransactionsParams().
 				WithDefaults().
 				WithAccountID(string(*account.AccountID)),
 			runtime.ClientAuthInfoWriterFunc(func(request runtime.ClientRequest, registry strfmt.Registry) error {
@@ -506,13 +505,13 @@ func (c *GenericBankClient) GetTransactions(ctx *gin.Context, accessToken string
 
 func (c *GenericBankClient) GetBalances(ctx *gin.Context, accessToken string, bank ConnectedBank) ([]Balance, error) {
 	var (
-		resp         *banking.ListBalancesBulkOK
+		resp         *cdrModels.ListBalancesBulkOK
 		balancesData []Balance
 		err          error
 	)
 
 	if resp, err = c.Banking.Banking.ListBalancesBulk(
-		banking.NewListBalancesBulkParams().
+		cdrModels.NewListBalancesBulkParams().
 			WithDefaults(),
 		runtime.ClientAuthInfoWriterFunc(func(request runtime.ClientRequest, registry strfmt.Registry) error {
 			return request.SetHeaderParam("Authorization", fmt.Sprintf("Bearer %s", accessToken))

--- a/apps/financroo-tpp/config.go
+++ b/apps/financroo-tpp/config.go
@@ -13,10 +13,11 @@ type BankID string
 type Spec string
 
 const (
-	OBUK Spec = "obuk"
-	OBBR Spec = "obbr"
-	CDR  Spec = "cdr"
-	FDX  Spec = "fdx"
+	OBUK    Spec = "obuk"
+	OBBR    Spec = "obbr"
+	CDR     Spec = "cdr"
+	FDX     Spec = "fdx"
+	GENERIC Spec = "generic"
 )
 
 type Config struct {
@@ -58,6 +59,8 @@ func (c *Config) SetImplicitValues() {
 			c.Currency = "BRL"
 		case OBUK:
 			c.Currency = "GBP"
+		case GENERIC:
+			c.Currency = "USD"
 		}
 	}
 }

--- a/apps/financroo-tpp/consent_commons.go
+++ b/apps/financroo-tpp/consent_commons.go
@@ -185,3 +185,16 @@ func (f *FDXLoginURLBuilder) BuildLoginURL(consentID string, client acpclient.Cl
 		acpclient.WithPAR(client.Config.ClientID, consentID),
 	)
 }
+
+type GenericLoginURLBuilder struct{}
+
+func NewGenericLoginURLBuilder(config Config) (LoginURLBuilder, error) {
+	return &GenericLoginURLBuilder{}, nil
+}
+
+func (f *GenericLoginURLBuilder) BuildLoginURL(consentID string, client acpclient.Client) (authorizeURL string, csrf acpclient.CSRF, err error) {
+	return client.AuthorizeURL(
+		acpclient.WithResponseType("code"),
+		acpclient.WithPAR(client.Config.ClientID, consentID),
+	)
+}

--- a/apps/financroo-tpp/server.go
+++ b/apps/financroo-tpp/server.go
@@ -77,7 +77,7 @@ func NewServer() (Server, error) {
 			return server, errors.Wrapf(err, "failed to create login url builder")
 		}
 	case GENERIC:
-		server.Config.ClientScopes = []string{"openid", "email", "custom", "offline_access"}
+		server.Config.ClientScopes = []string{"openid", "email", "sample", "offline_access"}
 		if server.Clients, err = InitClients(server.Config, nil, NewGenericBankClient, NewGenericConsentClient); err != nil {
 			return server, errors.Wrapf(err, "failed to create clients")
 		}

--- a/apps/financroo-tpp/server.go
+++ b/apps/financroo-tpp/server.go
@@ -60,7 +60,7 @@ func NewServer() (Server, error) {
 			return server, errors.Wrapf(err, "failed to create login url builder")
 		}
 	case CDR:
-		server.Config.ClientScopes = []string{"offline_access", "openid", "bank:accounts.basic:read", "bank:accounts.detail:read", "bank:transactions:read", "common:customer.basic:read"} // TODO
+		server.Config.ClientScopes = []string{"offline_access", "openid", "bank:accounts.basic:read", "bank:accounts.detail:read", "bank:transactions:read", "common:customer.basic:read"}
 		if server.Clients, err = InitClients(server.Config, nil, NewCDRClient, NewCDRConsentClient); err != nil {
 			return server, errors.Wrapf(err, "failed to create clients")
 		}
@@ -74,6 +74,15 @@ func NewServer() (Server, error) {
 		}
 
 		if server.LoginURLBuilder, err = NewFDXLoginURLBuilder(server.Config); err != nil {
+			return server, errors.Wrapf(err, "failed to create login url builder")
+		}
+	case GENERIC:
+		server.Config.ClientScopes = []string{"openid", "email", "custom", "offline_access"}
+		if server.Clients, err = InitClients(server.Config, nil, NewGenericBankClient, NewGenericConsentClient); err != nil {
+			return server, errors.Wrapf(err, "failed to create clients")
+		}
+
+		if server.LoginURLBuilder, err = NewGenericLoginURLBuilder(server.Config); err != nil {
 			return server, errors.Wrapf(err, "failed to create login url builder")
 		}
 	default:

--- a/consent/consent-page/cdr_consent_tools.go
+++ b/consent/consent-page/cdr_consent_tools.go
@@ -12,7 +12,7 @@ type CDRConsentTools struct {
 }
 
 func (c *CDRConsentTools) GetInternalBankDataIdentifier(sub string, authCtx cdrModels.AuthenticationContext) string {
-	if c.Config.BankIDClaim == "sub" {
+	if c.Config.BankIDClaim == SubClaim {
 		return sub
 	}
 
@@ -89,7 +89,7 @@ func (c *CDRConsentTools) GetClientName(client *cdrModels.ClientInfo) string {
 		return client.ClientName
 	}
 
-	return "TPP"
+	return DefaultTPPName
 }
 
 func (c *CDRConsentTools) GrantScopes(requestedScopes []*cdrModels.RequestedScope) []string {

--- a/consent/consent-page/const.go
+++ b/consent/consent-page/const.go
@@ -1,0 +1,6 @@
+package main
+
+const (
+	DefaultTPPName = "TPP"
+	SubClaim       = "sub"
+)

--- a/consent/consent-page/fdx_consent_tools.go
+++ b/consent/consent-page/fdx_consent_tools.go
@@ -17,7 +17,7 @@ func (c *FDXConsentTools) GetClientName(client *models.ClientInfo) string {
 		return client.ClientName
 	}
 
-	return "TPP"
+	return DefaultTPPName
 }
 
 func (c *FDXConsentTools) GetAccessConsentTemplateData(
@@ -76,7 +76,7 @@ func (c *FDXConsentTools) GetPermissionsWithDescription(requestedPermissions []s
 }
 
 func (c *FDXConsentTools) GetInternalBankDataIdentifier(sub string, authCtx models.AuthenticationContext) string {
-	if c.Config.BankIDClaim == "sub" {
+	if c.Config.BankIDClaim == SubClaim {
 		return sub
 	}
 

--- a/consent/consent-page/generic_client.go
+++ b/consent/consent-page/generic_client.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/cloudentity/openbanking-quickstart/generated/cdr/models"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+type GenericBankClient struct {
+	httpClient       *http.Client
+	bankClientConfig BankClientConfig
+	cc               clientcredentials.Config
+}
+
+func NewGenericBankClient(config Config) *GenericBankClient {
+	var (
+		pool  *x509.CertPool
+		cert  tls.Certificate
+		data  []byte
+		certs []tls.Certificate
+		err   error
+	)
+
+	if pool, err = x509.SystemCertPool(); err != nil {
+		logrus.Fatalf("failed to read system root CAs %v", err)
+	}
+
+	if data, err = os.ReadFile(config.RootCA); err != nil {
+		logrus.Fatalf("failed to read http client root ca: %v", err)
+	}
+	pool.AppendCertsFromPEM(data)
+
+	if config.BankClientConfig.CertFile != "" && config.BankClientConfig.KeyFile != "" {
+		if cert, err = tls.LoadX509KeyPair(config.BankClientConfig.CertFile, config.BankClientConfig.KeyFile); err != nil {
+			logrus.Fatalf("failed to read certificate and private key %v", err)
+		}
+		certs = append(certs, cert)
+	}
+
+	return &GenericBankClient{
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				TLSClientConfig: &tls.Config{
+					RootCAs:      pool,
+					MinVersion:   tls.VersionTLS12,
+					Certificates: certs,
+				},
+			},
+		},
+		cc: clientcredentials.Config{
+			ClientID:     config.BankClientConfig.ClientID,
+			ClientSecret: config.BankClientConfig.ClientSecret,
+			TokenURL:     config.BankClientConfig.TokenURL,
+			Scopes:       config.BankClientConfig.Scopes,
+		},
+		bankClientConfig: config.BankClientConfig,
+	}
+}
+
+func (c *GenericBankClient) GetInternalAccounts(ctx context.Context, id string) (InternalAccounts, error) {
+	var (
+		token                *oauth2.Token
+		request              *http.Request
+		response             *http.Response
+		accountsEndpointPath string
+		body                 []byte
+		err                  error
+	)
+
+	if c.bankClientConfig.AccountsURL != nil {
+		accountsEndpointPath = c.bankClientConfig.AccountsURL.String()
+	} else {
+		accountsEndpointPath = c.bankClientConfig.URL.String() + "/internal/accounts"
+	}
+
+	if token, err = c.cc.Token(context.WithValue(ctx, oauth2.HTTPClient, c.httpClient)); err != nil {
+		return InternalAccounts{}, errors.Wrapf(err, "failed to get client credentials token for internal bank api call")
+	}
+
+	if request, err = http.NewRequestWithContext(ctx, http.MethodPost, accountsEndpointPath, strings.NewReader(
+		url.Values{
+			"customer_id": []string{id},
+		}.Encode(),
+	)); err != nil {
+		return InternalAccounts{}, err
+	}
+
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Authorization", "Bearer "+token.AccessToken)
+
+	if response, err = c.httpClient.Do(request); err != nil {
+		return InternalAccounts{}, errors.Wrapf(err, "internal bank accounts api call failed")
+	}
+	defer response.Body.Close()
+
+	if body, err = ioutil.ReadAll(response.Body); err != nil {
+		return InternalAccounts{}, errors.Wrap(err, "internal bank accounts api call failed")
+	}
+
+	if response.StatusCode >= http.StatusBadRequest {
+		return InternalAccounts{}, errors.Wrap(errors.New(string(body)), "internal bank accounts api call failed")
+	}
+
+	return c.accountsResponseToInternalAccounts(body)
+}
+
+func (c *GenericBankClient) accountsResponseToInternalAccounts(body []byte) (accounts InternalAccounts, err error) {
+	var accountListResponse models.ResponseBankingAccountList
+
+	if err = json.Unmarshal(body, &accountListResponse); err != nil {
+		return accounts, err
+	}
+
+	for _, acc := range accountListResponse.Data.Accounts {
+		accounts.Accounts = append(accounts.Accounts, InternalAccount{
+			ID:   *acc.AccountID,
+			Name: acc.Nickname,
+		})
+	}
+
+	return accounts, nil
+}
+
+func (c *GenericBankClient) GetInternalBalances(ctx context.Context, id string) (BalanceResponse, error) {
+	return BalanceResponse{}, nil
+}

--- a/consent/consent-page/generic_consent_handler.go
+++ b/consent/consent-page/generic_consent_handler.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+
+	"github.com/cloudentity/acp-client-go/clients/system/client/logins"
+	"github.com/cloudentity/acp-client-go/clients/system/models"
+)
+
+type GenericAccountAccessConsentHandler struct {
+	*Server
+	GenericConsentTools
+}
+
+func (s *GenericAccountAccessConsentHandler) GetConsent(c *gin.Context, loginRequest LoginRequest) {
+	var (
+		response *logins.GetScopeGrantRequestOK
+		err      error
+	)
+
+	if response, err = s.Client.System.Logins.GetScopeGrantRequest(
+		logins.NewGetScopeGrantRequestParamsWithContext(c).WithLogin(loginRequest.ID),
+		nil,
+	); err != nil {
+		RenderInternalServerError(c, s.Server.Trans, errors.Wrapf(err, "failed to get login session"))
+		return
+	}
+
+	// TODO call bank
+	accounts := InternalAccounts{
+		Accounts: []InternalAccount{
+			{
+				ID:          "123",
+				Name:        "Savings",
+				Balance:     Balance{},
+				Preselected: true,
+			},
+		},
+	}
+
+	// var (
+	// 	accounts InternalAccounts
+	// 	response *obukModels.GetAccountAccessConsentSystemOK
+	// 	err      error
+	// 	id       string
+	// )
+
+	// if response, err = s.Client.Obuk.Consentpage.GetAccountAccessConsentSystem(
+	// 	obukModels.NewGetAccountAccessConsentSystemParamsWithContext(c).
+	// 		WithLogin(loginRequest.ID),
+	// 	nil,
+	// ); err != nil {
+	// 	RenderInternalServerError(c, s.Server.Trans, errors.Wrapf(err, "failed to get account access consent"))
+	// 	return
+	// }
+
+	// id := s.GenericConsentTools.GetInternalBankDataIdentifier(response.Payload.Subject, response.Payload.AuthenticationContext)
+
+	// if accounts, err = s.BankClient.GetInternalAccounts(c, id); err != nil {
+	// 	RenderInternalServerError(c, s.Server.Trans, errors.Wrapf(err, "failed to get accounts from bank"))
+	// 	return
+	// }
+
+	Render(c, s.GetTemplateNameForSpec("account-consent.tmpl"), s.GetAccessConsentTemplateData(loginRequest, response.Payload, accounts))
+}
+
+func (s *GenericAccountAccessConsentHandler) ConfirmConsent(c *gin.Context, loginRequest LoginRequest) (string, error) {
+	var (
+		response      *logins.GetScopeGrantRequestOK
+		accept        *logins.AcceptScopeGrantRequestOK
+		grantedScopes = []string{}
+		err           error
+	)
+
+	if response, err = s.Client.System.Logins.GetScopeGrantRequest(
+		logins.NewGetScopeGrantRequestParamsWithContext(c).WithLogin(loginRequest.ID),
+		nil,
+	); err != nil {
+		return "", errors.Wrapf(err, "failed to get login session")
+	}
+
+	// TODO store consent in the external service
+	externalConsentID := "external-consent-id"
+
+	for _, scp := range response.Payload.RequestedScopes {
+		grantedScopes = append(grantedScopes, scp.RequestedName)
+	}
+
+	if accept, err = s.Client.System.Logins.AcceptScopeGrantRequest(
+		logins.NewAcceptScopeGrantRequestParamsWithContext(c).
+			WithLogin(loginRequest.ID).
+			WithAcceptScopeGrant(&models.AcceptScopeGrant{
+				GrantedScopes: grantedScopes,
+				LoginState:    loginRequest.State,
+				ConsentID:     externalConsentID,
+			}),
+		nil,
+	); err != nil {
+		return "", err
+	}
+
+	return accept.Payload.RedirectTo, nil
+}
+
+func (s *GenericAccountAccessConsentHandler) DenyConsent(c *gin.Context, loginRequest LoginRequest) (string, error) {
+	var (
+		response *logins.RejectScopeGrantRequestOK
+		err      error
+	)
+
+	if response, err = s.Client.System.Logins.RejectScopeGrantRequest(
+		logins.NewRejectScopeGrantRequestParamsWithContext(c).
+			WithLogin(loginRequest.ID).
+			WithRejectScopeGrant(&models.RejectScopeGrant{
+				ID:               loginRequest.ID,
+				LoginState:       loginRequest.State,
+				Error:            "rejected",
+				ErrorCause:       "consent_rejected",
+				ErrorDescription: "The user rejected the authentication.",
+				StatusCode:       403,
+			}),
+		nil,
+	); err != nil {
+		return "", err
+	}
+
+	return response.Payload.RedirectTo, nil
+}
+
+var _ ConsentHandler = &GenericAccountAccessConsentHandler{}

--- a/consent/consent-page/generic_consent_tools.go
+++ b/consent/consent-page/generic_consent_tools.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/cloudentity/acp-client-go/clients/system/models"
+)
+
+type GenericConsentTools struct {
+	Trans  *Trans
+	Config Config
+}
+
+func (c *GenericConsentTools) GetClientName(client *models.ClientInfo) string {
+	if client != nil {
+		return client.ClientName
+	}
+
+	return "TPP"
+}
+
+func (c *GenericConsentTools) GetAccessConsentTemplateData(
+	loginRequest LoginRequest,
+	consent *models.ScopeGrantSessionResponse,
+	accounts InternalAccounts,
+) map[string]interface{} {
+
+	clientName := c.GetClientName(consent.ClientInfo)
+	return map[string]interface{}{
+		"trans": map[string]interface{}{
+			"headTitle":      c.Trans.T("uk.account.headTitle"),
+			"title":          c.Trans.T("uk.account.title"),
+			"selectAccounts": c.Trans.T("uk.account.selectAccounts"),
+			"reviewData":     c.Trans.T("uk.account.review_data"),
+			"purpose":        c.Trans.T("uk.account.purpose"),
+			"purposeDetail":  c.Trans.T("uk.account.purposeDetail"),
+			"expiration": c.Trans.TD("uk.account.expiration", map[string]interface{}{
+				"client_name": clientName,
+				// "expiration_date": expirationDate,
+			}),
+			"cancel": c.Trans.T("uk.account.cancel"),
+			"agree":  c.Trans.T("uk.account.agree"),
+		},
+		"login_request": loginRequest,
+		"accounts":      accounts.Accounts,
+		"client_name":   clientName,
+		// "expiration_date": expirationDate,
+		"ctx": consent.AuthenticationContext,
+	}
+}
+
+func (c *GenericConsentTools) GetInternalBankDataIdentifier(sub string, authCtx models.AuthenticationContext) string {
+	if c.Config.BankIDClaim == "sub" {
+		return sub
+	}
+
+	return fmt.Sprintf("%v", authCtx[c.Config.BankIDClaim])
+}

--- a/consent/consent-page/generic_consent_tools.go
+++ b/consent/consent-page/generic_consent_tools.go
@@ -16,7 +16,7 @@ func (c *GenericConsentTools) GetClientName(client *models.ClientInfo) string {
 		return client.ClientName
 	}
 
-	return "TPP"
+	return DefaultTPPName
 }
 
 func (c *GenericConsentTools) GetAccessConsentTemplateData(
@@ -24,7 +24,6 @@ func (c *GenericConsentTools) GetAccessConsentTemplateData(
 	consent *models.ScopeGrantSessionResponse,
 	accounts InternalAccounts,
 ) map[string]interface{} {
-
 	clientName := c.GetClientName(consent.ClientInfo)
 	return map[string]interface{}{
 		"trans": map[string]interface{}{
@@ -50,7 +49,7 @@ func (c *GenericConsentTools) GetAccessConsentTemplateData(
 }
 
 func (c *GenericConsentTools) GetInternalBankDataIdentifier(sub string, authCtx models.AuthenticationContext) string {
-	if c.Config.BankIDClaim == "sub" {
+	if c.Config.BankIDClaim == SubClaim {
 		return sub
 	}
 

--- a/consent/consent-page/handler.go
+++ b/consent/consent-page/handler.go
@@ -23,15 +23,26 @@ func NewLoginRequest(c *gin.Context) LoginRequest {
 	}
 }
 
-func (l *LoginRequest) Validate() error {
-	if l.ID == "" || l.State == "" || l.ConsentType == "" {
-		return errors.New("login_id / login_state / consent_type missing")
+func (l *LoginRequest) Validate(spec Spec) error {
+	if l.ID == "" || l.State == "" {
+		return errors.New("login_id / login_state query param missing")
+	}
+
+	switch spec {
+	case Generic:
+	default:
+		if l.ConsentType == "" {
+			return errors.New("consent_type query param missing")
+		}
 	}
 
 	return nil
 }
 
 func (s *Server) GetTemplateNameForSpec(basename string) string {
+	logrus.Infof("XXX GetTemplateNameForSpec %+v", basename)
+
+	return string(s.Config.Spec) + "-" + basename
 	switch s.Config.Spec {
 	case OBUK:
 		return string(OBUK) + "-" + basename
@@ -41,6 +52,8 @@ func (s *Server) GetTemplateNameForSpec(basename string) string {
 		return string(CDR) + "-" + basename
 	case FDX:
 		return string(FDX) + "-" + basename
+	case Generic:
+		return string(Generic) + "-" + basename
 	}
 
 	return basename
@@ -54,7 +67,7 @@ func (s *Server) WithConsentHandler(c *gin.Context) (ConsentHandler, LoginReques
 		ok           bool
 	)
 
-	if err = loginRequest.Validate(); err != nil {
+	if err = loginRequest.Validate(s.Config.Spec); err != nil {
 		return handler, loginRequest, err
 	}
 
@@ -129,10 +142,14 @@ func (s *Server) PostConsent(c *gin.Context, loginRequest LoginRequest, consentH
 }
 
 func (s *Server) GetConsentHandler(loginRequest LoginRequest) (ConsentHandler, bool) {
+	logrus.Infof("XXX GetConsentHandler: %+v", loginRequest.ConsentType)
+
 	switch loginRequest.ConsentType {
 	case "domestic_payment", "payments":
 		return s.PaymentConsentHandler, true
 	case "account_access", "consents", "cdr_arrangement", "fdx":
+		return s.AccountAccessConsentHandler, true
+	case "": // generic consent does not have a consent type
 		return s.AccountAccessConsentHandler, true
 	default:
 		return nil, false

--- a/consent/consent-page/handler.go
+++ b/consent/consent-page/handler.go
@@ -40,9 +40,6 @@ func (l *LoginRequest) Validate(spec Spec) error {
 }
 
 func (s *Server) GetTemplateNameForSpec(basename string) string {
-	logrus.Infof("XXX GetTemplateNameForSpec %+v", basename)
-
-	return string(s.Config.Spec) + "-" + basename
 	switch s.Config.Spec {
 	case OBUK:
 		return string(OBUK) + "-" + basename

--- a/consent/consent-page/main.go
+++ b/consent/consent-page/main.go
@@ -222,7 +222,7 @@ func NewServer() (Server, error) {
 	case FDX:
 		server.BankClient = NewFDXClient(server.Config)
 	case Generic:
-		server.BankClient = NewOBBRBankClient(server.Config)
+		server.BankClient = NewGenericBankClient(server.Config)
 	default:
 		return Server{}, errors.New("invalid SPEC configuration")
 	}

--- a/consent/consent-page/mfa_handler.go
+++ b/consent/consent-page/mfa_handler.go
@@ -217,7 +217,7 @@ func (s *Server) MFAHandler() func(*gin.Context) {
 			err             error
 		)
 
-		if err = r.Validate(); err != nil {
+		if err = r.Validate(s.Config.Spec); err != nil {
 			RenderInvalidRequestError(c, s.Trans, err)
 			return
 		}

--- a/consent/consent-page/obbr_consent_tools.go
+++ b/consent/consent-page/obbr_consent_tools.go
@@ -17,7 +17,7 @@ func (c *OBBRConsentTools) GetClientName(client *obbrModels.ClientInfo) string {
 		return client.ClientName
 	}
 
-	return "TPP"
+	return DefaultTPPName
 }
 
 func (c *OBBRConsentTools) GetAccessConsentTemplateData(
@@ -83,7 +83,7 @@ func (c *OBBRConsentTools) GetPermissionsWithDescription(requestedPermissions []
 }
 
 func (c *OBBRConsentTools) GetInternalBankDataIdentifier(sub string, authCtx obbrModels.AuthenticationContext) string {
-	if c.Config.BankIDClaim == "sub" {
+	if c.Config.BankIDClaim == SubClaim {
 		return sub
 	}
 

--- a/consent/consent-page/obuk_consent_tools.go
+++ b/consent/consent-page/obuk_consent_tools.go
@@ -17,7 +17,7 @@ func (c *OBUKConsentTools) GetClientName(client *obukModels.ClientInfo) string {
 		return client.ClientName
 	}
 
-	return "TPP"
+	return DefaultTPPName
 }
 
 func (c *OBUKConsentTools) GetAccessConsentTemplateData(
@@ -135,7 +135,7 @@ func (c *OBUKConsentTools) GetAccountsWithBalance(accounts InternalAccounts, bal
 }
 
 func (c *OBUKConsentTools) GetInternalBankDataIdentifier(sub string, authCtx obukModels.AuthenticationContext) string {
-	if c.Config.BankIDClaim == "sub" {
+	if c.Config.BankIDClaim == SubClaim {
 		return sub
 	}
 

--- a/consent/consent-page/templates/base/generic-account-consent.tmpl
+++ b/consent/consent-page/templates/base/generic-account-consent.tmpl
@@ -1,0 +1,114 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
+
+<html>
+<head>
+  {{ template "imports.tmpl" }}
+  <title>{{.trans.headTitle}}</title>
+</head>
+
+<body>
+<div class="header">
+  <img src="/assets/images/bank_logo.svg"/>
+</div>
+<div id="background-image">
+  <img src="/assets/images/background_image.svg"/>
+</div>
+
+{{ if or .mfaRequest .mfaConfirmation }}
+<div class="content mfa-required">
+  {{ else }}
+  <div class="content">
+    {{ end }}
+
+    <div class="icon-logo">
+      <img src="/assets/images/account_access_logo.svg"/>
+    </div>
+
+    <p class="consent-title">{{ .trans.title }}</p>
+
+    <form action="?login_id={{ .login_request.ID }}&login_state={{ .login_request.State }}&consent_type={{ .login_request.ConsentType }}"
+          method="post">
+      <div class="form-block">
+        <div class="form-block-title">{{.trans.selectAccounts}} {{ .client_name }}</div>
+        <div class="accounts-block">
+          {{ range .accounts }}
+            <div class="account-row">
+              <div class="account-header">
+                <div>
+                  <div class="account-header-title">{{ .Name }}</div>
+                  <div class="caption account-header-subtitle">**** **** **** {{ .ID }}</div>
+                </div>
+                <div class="mdc-switch">
+                  <div class="mdc-switch__track"></div>
+                  <div class="mdc-switch__thumb-underlay">
+                    <div class="mdc-switch__thumb"></div>
+                    <input
+                            type="checkbox"
+                            id="account-id-{{ .ID }}"
+                            name="account_ids"
+                            value="{{ .ID }}"
+                            class="mdc-switch__native-control"
+                            role="switch"
+                            aria-checked="true"
+                            checked
+                    >
+                  </div>
+                </div>
+              </div>
+            </div>
+          {{ end }}
+        </div>
+
+        {{ if .expiration_date }}
+        <p class="caption" style="text-align: center; margin: 32px 0;">{{.trans.expiration}}</p>
+        {{ end }}
+
+        <div class="form-actions">
+          <button class="mdc-button mdc-button--outlined cancel-button" type="submit" name="action" value="deny"
+                  {{ if or .mfaRequest .mfaConfirmation }} disabled {{end}}
+          >
+            <div class="mdc-button__ripple"></div>
+            <span class="mdc-button__label">{{.trans.cancel}}</span>
+          </button>
+          <button class="mdc-button mdc-button--raised confirm-button" type="submit" name="action" value="confirm"
+                  {{ if or .mfaRequest .mfaConfirmation }} disabled {{end}}
+          >
+            <div class="mdc-button__ripple"></div>
+            <span class="mdc-button__label">{{.trans.agree}}</span>
+          </button>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  {{ if .mfaRequest }}
+    {{ template "mfa-request.tmpl" . }}
+  {{ end }}
+
+  {{ if .mfaConfirmation }}
+    {{ template "mfa-verify.tmpl" .}}
+  {{ end }}
+    </div>
+</body>
+
+<script>
+  function toggle(value) {
+    var el = document.querySelector("[data-desc-id='" + value + "']");
+    if (el.classList.contains('account-description-visible')) {
+      el.classList.remove("account-description-visible");
+      el.classList.add("account-description-hidden");
+      document.querySelector("[data-icon-id='" + value + "']").innerText = "keyboard_arrow_down";
+    } else {
+      el.classList.remove("account-description-hidden");
+      el.classList.add("account-description-visible");
+      document.querySelector("[data-icon-id='" + value + "']").innerText = "keyboard_arrow_up";
+    }
+
+    return false;
+  }
+
+  var switchControls = [].map.call(document.querySelectorAll('.mdc-switch'), function (el) {
+    return new window.mdc.switchControl.MDCSwitch(el)
+  });
+</script>
+</html>

--- a/data/imports/generic/fapi.tmpl
+++ b/data/imports/generic/fapi.tmpl
@@ -4,6 +4,12 @@ servers:
   name: Open Finance Generic FAPI
   profile: {{ .server_profile }}
   initialize: true
+  {{ if .read_client_certificate_from_header }}
+  read_client_certificate_from_header: {{ .read_client_certificate_from_header }}
+  client_certificate_header: {{ .client_certificate_header }}
+  {{ end }}
+  root_cas: |
+{{ readFile .ca_pem_file | indent 4 }}
 
 idps:
 - tenant_id: {{ .tenant_id }}

--- a/data/imports/generic/fapi.tmpl
+++ b/data/imports/generic/fapi.tmpl
@@ -52,23 +52,22 @@ clients:
   - manage_scope_grants
   token_endpoint_auth_method: client_secret_basic
 
-# - tenant_id:  {{ .tenant_id }}
-#   authorization_server_id: {{ .server_id }}
-#   client_id: {{ .bank_client_id }}
-#   client_name: bank
-#   description: bank resource server app used to introspect tokens
-#   client_secret: {{ .bank_client_secret }}
-#   grant_types:
-#   - client_credentials
-#   scopes:
-#   - introspect_openbanking_tokens
-#   - introspect_tokens
-#   - revoke_tokens
-#   subject_type: pairwise
-#   system: true
-#   tls_client_auth_subject_dn: {{ .bank_tls_client_auth_subject_dn }}
-#   tls_client_certificate_bound_access_tokens: true
-#   token_endpoint_auth_method: tls_client_auth
+- tenant_id:  {{ .tenant_id }}
+  authorization_server_id: {{ .server_id }}
+  client_id: {{ .bank_client_id }}
+  client_name: bank
+  description: bank resource server app used to introspect tokens
+  client_secret: {{ .bank_client_secret }}
+  grant_types:
+  - client_credentials
+  scopes:
+  - introspect_tokens
+  - revoke_tokens
+  subject_type: pairwise
+  system: true
+  tls_client_auth_subject_dn: {{ .bank_tls_client_auth_subject_dn }}
+  tls_client_certificate_bound_access_tokens: true
+  token_endpoint_auth_method: tls_client_auth
 
 # financroo
 - tenant_id: {{ .tenant_id }}

--- a/data/imports/generic/fapi.tmpl
+++ b/data/imports/generic/fapi.tmpl
@@ -4,6 +4,10 @@ servers:
   name: Open Finance Generic FAPI
   profile: {{ .server_profile }}
   initialize: true
+  token_endpoint_auth_methods:
+    - private_key_jwt
+    - client_secret_post
+    - tls_client_auth
   {{ if .read_client_certificate_from_header }}
   read_client_certificate_from_header: {{ .read_client_certificate_from_header }}
   client_certificate_header: {{ .client_certificate_header }}
@@ -97,6 +101,15 @@ clients:
   - refresh_token
   jwks:
 {{ readFile .financroo_pem_file | pemToPublicJwks | indent 4 }}
+
+- tenant_id: {{ .tenant_id }}
+  authorization_server_id: {{ .server_id }}
+  client_id: {{ .internal_bank_client_id }}
+  client_secret: {{ .internal_bank_client_secret }}
+  client_name: Consent Page Bank Client
+  grant_types:
+  - client_credentials
+  token_endpoint_auth_method: client_secret_post
 
 services:
 - authorization_server_id: {{ .server_id }}

--- a/data/imports/generic/fapi.tmpl
+++ b/data/imports/generic/fapi.tmpl
@@ -1,0 +1,107 @@
+servers:
+- tenant_id: {{ .tenant_id }}
+  id: {{ .server_id }}
+  name: Open Finance Generic FAPI
+  profile: {{ .server_profile }}
+  initialize: true
+
+idps:
+- tenant_id: {{ .tenant_id }}
+  authorization_server_id: {{ .server_id }}
+  id: bugkgai3g9kregtu04u0
+  name: Sandbox IDP
+  method: static
+  settings:
+    static:
+      hint: true
+  credentials:
+    static:
+      users:
+      - username: user
+        password: p@ssw0rd!
+        email: user@example.com
+        email_verified: true
+        additional_attributes:
+          given_name: Joe
+          family_name: Doe
+
+server_consents:
+- tenant_id: {{ .tenant_id }}
+  client_id: {{ .consent_page_client_id }}
+  custom:
+    server_consent_url: {{ .consent_page_url }}
+  server_id: {{ .server_id }}
+  type: custom
+
+clients:
+# consent page
+- tenant_id: {{ .tenant_id }}
+  authorization_server_id: system
+  client_id: {{ .consent_page_client_id }}
+  client_secret: {{ .consent_page_client_secret }}
+  client_name: custom server consent
+  grant_types:
+  - client_credentials
+  scopes:
+  - manage_scope_grants
+  token_endpoint_auth_method: client_secret_basic
+
+# - tenant_id:  {{ .tenant_id }}
+#   authorization_server_id: {{ .server_id }}
+#   client_id: {{ .bank_client_id }}
+#   client_name: bank
+#   description: bank resource server app used to introspect tokens
+#   client_secret: {{ .bank_client_secret }}
+#   grant_types:
+#   - client_credentials
+#   scopes:
+#   - introspect_openbanking_tokens
+#   - introspect_tokens
+#   - revoke_tokens
+#   subject_type: pairwise
+#   system: true
+#   tls_client_auth_subject_dn: {{ .bank_tls_client_auth_subject_dn }}
+#   tls_client_certificate_bound_access_tokens: true
+#   token_endpoint_auth_method: tls_client_auth
+
+# financroo
+- tenant_id: {{ .tenant_id }}
+  authorization_server_id: {{ .server_id }}
+  client_id: {{ .financroo_tpp_client_id }}
+  client_name: Financroo
+  client_uri: https://localhost:8090
+  client_secret: {{ .financroo_tpp_client_secret }}
+  tls_client_auth_subject_dn: {{ .financroo_tls_client_auth_subject_dn }}
+  tls_client_certificate_bound_access_tokens: true
+  token_endpoint_auth_method: tls_client_auth
+  redirect_uris:
+  - {{ .financroo_tpp_url }}/api/callback
+  - {{ .financroo_tpp_url }}/api/domestic/callback
+  subject_type: pairwise
+  request_object_signing_alg: RS256
+  response_types:
+  - code
+  scopes:
+  - offline_access
+  - openid
+  - email
+  - sample
+  grant_types:
+  - client_credentials
+  - authorization_code
+  - refresh_token
+  jwks:
+{{ readFile .financroo_pem_file | pemToPublicJwks | indent 4 }}
+
+services:
+- authorization_server_id: {{ .server_id }}
+  id: {{ .server_id}}-sample
+  name: Sample
+  tenant_id: {{ .tenant_id }}
+  scopes:
+  - authorization_server_id: {{ .server_id }}
+    id: sample
+    name: sample
+    tenant_id: {{ .tenant_id }}
+    transient: true
+    implicit: true

--- a/data/imports/generic/system.tmpl
+++ b/data/imports/generic/system.tmpl
@@ -1,0 +1,15 @@
+clients:
+- tenant_id: {{ .tenant_id }}
+  authorization_server_id: system
+  client_id: {{ .system_bank_client_id }}
+  client_name: Bank
+  client_secret: {{ .system_bank_client_secret }}
+  grant_types:
+  - client_credentials
+  scopes:
+  - introspect_tokens
+  - revoke_tokens
+  - view_clients
+  tls_client_auth_subject_dn: {{ .bank_tls_client_auth_subject_dn }}
+  tls_client_certificate_bound_access_tokens: true
+  token_endpoint_auth_method: client_secret_post

--- a/data/imports/generic/tenant.tmpl
+++ b/data/imports/generic/tenant.tmpl
@@ -1,0 +1,3 @@
+tenants:
+- id: default
+  name: default

--- a/docker-compose.acp.local.yaml
+++ b/docker-compose.acp.local.yaml
@@ -88,7 +88,7 @@ services:
       - 8006:8001
 
   jaeger:
-    container_name: jaeger
+    container_name: quickstart-jaeger
     image: jaegertracing/all-in-one:1.17
     platform: linux/x86_64
     restart: on-failure

--- a/docker-compose.generic.yaml
+++ b/docker-compose.generic.yaml
@@ -64,7 +64,7 @@ services:
       - ./data/ca.pem:/ca.pem
       - ./data/bank_cert.pem:/bank_cert.pem
       - ./data/bank_key.pem:/bank_key.pem
-      - ./mount/bank-br:/app/data
+      - ./mount/bank-generic:/app/data
     environment:
       - ISSUER_URL=${ACP_MTLS_URL}/${TENANT}/${SERVER}
       - SPEC=generic

--- a/docker-compose.generic.yaml
+++ b/docker-compose.generic.yaml
@@ -1,0 +1,104 @@
+version: "3.0"
+
+services:
+  financroo-tpp:
+    image: cloudentity/openbanking-quickstart-financroo-tpp:${VERSION}
+    container_name: financroo-tpp
+    platform: linux/x86_64
+    restart: always
+    ports:
+      - "8091:8091"
+    volumes:
+      - ./data:/certs
+      - ./mount/financroo-tpp:/app/data
+    env_file:
+      - .env
+    environment:
+      - UI_URL=https://${APP_HOST}:8091
+      - TENANT=${TENANT}
+      - GIN_MODE=debug # change to release to disable gin debug
+      - SPEC=generic
+      - BANK_URL=http://bank:8070
+      - OPENBANKING_SERVER_ID=${SERVER}
+      - ENABLE_TLS_SERVER=true
+      - CLIENT_ID=${FINANCROO_TPP_CLIENT_ID}
+    depends_on:
+      configuration:
+        condition: service_completed_successfully
+
+  consent-page:
+    image: cloudentity/openbanking-quickstart-consent-page:${VERSION}
+    container_name: consent-page
+    platform: linux/x86_64
+    restart: always
+    ports:
+      - "7080:8080"
+    volumes:
+      - ./mount/consent-page:/data
+      - ./data/ca.pem:/ca.pem
+      - ./data/bank_cert.pem:/bank_cert.pem
+      - ./data/bank_key.pem:/bank_key.pem
+    env_file:
+      - .env
+    environment:
+      - ISSUER_URL=${ACP_MTLS_URL}/${TENANT}/system
+      - BANK_URL=http://bank:8070
+      - LOG_LEVEL=debug
+      - SPEC=generic
+      - GIN_MODE=debug # change to release to disable gin debug
+      - OTP_MODE=mock # change to custom to enable custom OTP handling
+      - MFA_CLAIM=sub # for mobile use mobile_verified
+      - CLIENT_ID=${CONSENT_PAGE_CLIENT_ID}
+    depends_on:
+      configuration:
+        condition: service_completed_successfully
+
+  bank:
+    image: cloudentity/openbanking-quickstart-bank:${VERSION}
+    container_name: bank
+    platform: linux/x86_64
+    restart: always
+    ports:
+      - "8070:8070"
+    volumes:
+      - ./data/ca.pem:/ca.pem
+      - ./data/bank_cert.pem:/bank_cert.pem
+      - ./data/bank_key.pem:/bank_key.pem
+      - ./mount/bank-br:/app/data
+    environment:
+      - ISSUER_URL=${ACP_MTLS_URL}/${TENANT}/${SERVER}
+      - SPEC=generic
+      - GIN_MODE=debug
+      - CLIENT_ID=${BANK_CLIENT_ID}
+    depends_on:
+      configuration:
+        condition: service_completed_successfully
+
+  configuration:
+    container_name: configuration
+    platform: linux/x86_64
+    image: cloudentity/openbanking-quickstart-configuration:latest
+    restart: on-failure
+    volumes:
+      - ./data/tpp_cert.pem:/certs/tpp_cert.pem
+      - ./data/ca.pem:/certs/ca.pem
+      - ./data/variables.yaml:/variables.yaml
+      - ./data/imports/generic/system.tmpl:/app/imports-generic/system.tmpl
+      # - ./data/imports/bank-customers.tmpl:/app/imports-generic/bank-customers.tmpl
+      - ./data/imports/generic/fapi.tmpl:/app/imports-generic/fapi.tmpl
+      - ./data/imports/generic/tenant.tmpl:/app/imports-generic/tenant.tmpl
+    command:
+      - /app/main
+      - --tenant-url
+      - ${CONFIGURATION_TENANT_URL}
+      - --tenant
+      - ${CONFIGURATION_TENANT}
+      - --client-id
+      - ${CONFIGURATION_CLIENT_ID}
+      - --client-secret
+      - ${CONFIGURATION_CLIENT_SECRET}
+      - --templates-dirs
+      - /app/imports-generic
+      - --variables-file
+      - /variables.yaml
+      - --verbose

--- a/docker-compose.generic.yaml
+++ b/docker-compose.generic.yaml
@@ -43,6 +43,10 @@ services:
     environment:
       - ISSUER_URL=${ACP_MTLS_URL}/${TENANT}/system
       - BANK_URL=http://bank:8070
+      - BANK_ACCOUNTS_ENDPOINT=http://bank:8070/internal/accounts
+      - BANK_CLIENT_TOKEN_URL=${ACP_URL}/${TENANT}/${SERVER}/oauth2/token
+      - BANK_CLIENT_ID=${INTERNAL_BANK_CLIENT_ID}
+      - BANK_CLIENT_SECRET=pMPBmv62z3Jt1S4sWl2qRhOhEGPVZ9EcujGL7Xy0-E0
       - LOG_LEVEL=debug
       - SPEC=generic
       - GIN_MODE=debug # change to release to disable gin debug

--- a/mount/bank-generic/generic-data.json
+++ b/mount/bank-generic/generic-data.json
@@ -1,0 +1,173 @@
+{
+	"user": {
+		"generic_accounts": [{
+				"accountId": "1000001",
+				"creationDate": "2015-01-01",
+				"displayName": "string",
+				"nickname": "Savings Account",
+				"openStatus": "OPEN",
+				"maskedNumber": "************001",
+				"productCategory": "string",
+				"productName": "string"
+			},
+			{
+				"accountId": "1000002",
+				"creationDate": "2015-01-01",
+				"displayName": "string",
+				"nickname": "Loan Account",
+				"openStatus": "OPEN",
+				"maskedNumber": "************002",
+				"productCategory": "string",
+				"productName": "string"
+			},
+			{
+				"accountId": "96534987",
+				"creationDate": "2015-01-01",
+				"displayName": "string",
+				"nickname": "Checkings Account",
+				"openStatus": "OPEN",
+				"maskedNumber": "************987",
+				"productCategory": "string",
+				"productName": "string"
+			}
+		],
+		"generic_transactions": [
+			{
+				"accountID": "1000001",
+				"TransactionId": "TRN11113",
+				"TransactionType": "PAYMENT",
+				"Status": "POSTED",
+				"Description": "emergency car repair",
+				"PostingDateTime": "2022-04-01T17:22:00Z",
+				"ValueDateTime": "2022-04-01T17:22:00Z",
+				"ExecutionDateTime": "2022-04-01T17:22:00Z",
+				"Amount": "512.97",
+				"Currency": "AUD",
+				"Reference": "EFTPOS",
+				"MerchantName": "Supermarket A",
+				"MerchantCategoryCode": "5411",
+				"BillerCode": "",
+				"BillerName": "",
+				"CRN": "",
+				"ApcaNumber": ""
+			},
+
+			{
+				"accountID": "96534987",
+				"TransactionId": "TRN11114",
+				"TransactionType": "PAYMENT",
+				"Status": "POSTED",
+				"Description": "rent payment",
+				"PostingDateTime": "2022-03-01T17:22:00Z",
+				"ValueDateTime": "2022-03-01T17:22:00Z",
+				"ExecutionDateTime": "2022-03-01T17:22:00Z",
+				"Amount": "800.00",
+				"Currency": "AUD",
+				"Reference": "EFTPOS",
+				"MerchantName": "Supermarket A",
+				"MerchantCategoryCode": "5411",
+				"BillerCode": "",
+				"BillerName": "",
+				"CRN": "",
+				"ApcaNumber": ""
+			},
+
+			{
+				"accountID": "96534987",
+				"TransactionId": "TRN11115",
+				"TransactionType": "PAYMENT",
+				"Status": "POSTED",
+				"Description": "dinner",
+				"PostingDateTime": "2022-04-18T17:22:00Z",
+				"ValueDateTime": "2022-04-18T17:22:00Z",
+				"ExecutionDateTime": "2022-04-18T17:22:00Z",
+				"Amount": "20.28",
+				"Currency": "AUD",
+				"Reference": "EFTPOS",
+				"MerchantName": "Supermarket A",
+				"MerchantCategoryCode": "5411",
+				"BillerCode": "",
+				"BillerName": "",
+				"CRN": "",
+				"ApcaNumber": ""
+			},
+
+			{
+				"accountID": "96534987",
+				"TransactionId": "TRN11116",
+				"TransactionType": "PAYMENT",
+				"Status": "POSTED",
+				"Description": "groceries",
+				"PostingDateTime": "2022-04-21T17:22:00Z",
+				"ValueDateTime": "2022-04-21T17:22:00Z",
+				"ExecutionDateTime": "2022-04-21T17:22:00Z",
+				"Amount": "111.2",
+				"Currency": "AUD",
+				"Reference": "EFTPOS",
+				"MerchantName": "Supermarket A",
+				"MerchantCategoryCode": "5411",
+				"BillerCode": "",
+				"BillerName": "",
+				"CRN": "",
+				"ApcaNumber": ""
+			},
+
+			{
+				"accountID": "96534987",
+				"TransactionId": "TRN11117",
+				"TransactionType": "PAYMENT",
+				"Status": "POSTED",
+				"Description": "car payment",
+				"PostingDateTime": "2022-04-20T17:22:00Z",
+				"ValueDateTime": "2022-04-20T17:22:00Z",
+				"ExecutionDateTime": "2022-04-20T17:22:00Z",
+				"Amount": "300.00",
+				"Currency": "AUD",
+				"Reference": "EFTPOS",
+				"MerchantName": "Supermarket A",
+				"MerchantCategoryCode": "5411",
+				"BillerCode": "",
+				"BillerName": "",
+				"CRN": "",
+				"ApcaNumber": ""
+			}
+		],
+		"generic_balances": [{
+				"accountId": "1000001",
+				"currentBalance": "1000.00",
+				"availableBalance": "1000.00",
+				"creditLimit": "string",
+				"amortisedLimit": "string",
+				"currency": "AUD",
+				"purses": [{
+					"amount": "string",
+					"currency": "string"
+				}]
+			},
+			{
+				"accountId": "1000002",
+				"currentBalance": "2330.45",
+				"availableBalance": "2330.45",
+				"creditLimit": "string",
+				"amortisedLimit": "string",
+				"currency": "AUD",
+				"purses": [{
+					"amount": "string",
+					"currency": "string"
+				}]
+			},
+			{
+				"accountId": "96534987",
+				"currentBalance": "1174.23",
+				"availableBalance": "1174.23",
+				"creditLimit": "string",
+				"amortisedLimit": "string",
+				"currency": "AUD",
+				"purses": [{
+					"amount": "string",
+					"currency": "string"
+				}]
+			}
+		]
+	}
+}

--- a/scripts/additional_configuration.sh
+++ b/scripts/additional_configuration.sh
@@ -95,6 +95,11 @@ do
     override_client_ids "fdx-developer-tpp" "fdx-financroo-tpp" "fdx-bank" "fdx-consent-page" "fdx-internal-bank-client" $system_clients
     ./scripts/override_variables.sh  "server_profile" "fdx"
     ;;
+  generic)
+    override_server "generic" "bank-customers" "generic"
+    override_client_ids "generic-developer-tpp" "generic-financroo-tpp" "generic-bank" "generic-consent-page" "generic-internal-bank-client" $system_clients
+    ./scripts/override_variables.sh  "server_profile" "fapi_20_security"
+    ;;
   *)
     exit
     ;;


### PR DESCRIPTION
## Jira task - [PUT_JIRA_LINK_HERE](https://cloudentity.atlassian.net/browse/AUT-9768)

## Release Notes Description (public)

Add new generic spec to financroo-tpp, consent-page and bank apps to showcase how generic openbanking could be build based on FAPI 2.0 security profile and external consent storage.

## Implementation details (internal)

The financroo TPP is using authorization code with PKCE, PAR and request object.

The consent page calls bank APIs to internally fetch accounts to be displayed to the user for approval. Since there is no specification for this interface, it's following CDR spec.

Upon approval the consent page accepts authorization grant by passing external consent id. Right now a dummy "external-consent-id" is used, however the code should be modified to actually create a consent in an external service and pass the unique consent id, so that the issued access token will be bound to the given consent.

The demo can be run using `make clean build run-generic-local`.
The financroo TPP is available at: `https://localhost:8091`

Please note that regardless of what accounts the user chooses on the consent page, it won't take any affect on TPP (it will always display all user accounts) as the the information about issued access token <-> granted accounts is currently not stored.
 
## Information for QA

<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Screenshots (if appropriate):
