### PR TITLE
ci: auto-approve Bump ACP image PRs

### DIFF
--- a/.github/workflows/update-acp-image.yml
+++ b/.github/workflows/update-acp-image.yml
@@ -46,3 +46,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_SERVICE_ACCOUNT_DEVOPS_2_PAT1 }}
         run: gh pr review --approve ${{ steps.create_pr.outputs.pr_number }}
+
+      - name: Enable auto-merge
+        if: steps.create_pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_SERVICE_ACCOUNT_DEVOPS_2_PAT1 }}
+        run: gh pr merge --auto --squash ${{ steps.create_pr.outputs.pr_number }}

--- a/.github/workflows/update-acp-image.yml
+++ b/.github/workflows/update-acp-image.yml
@@ -31,6 +31,7 @@ jobs:
           new_branch: bump-acp-image-${{ steps.date.outputs.date }}
 
       - name: Create PR
+        id: create_pr
         uses: devops-infra/action-pull-request@v0.5.3
         with:
           source_branch: bump-acp-image-${{ steps.date.outputs.date }}
@@ -39,3 +40,9 @@ jobs:
           body: "**Automated pull request**"
           draft: false
           allow_no_diff: false
+
+      - name: Auto-approve PR
+        if: steps.create_pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_SERVICE_ACCOUNT_DEVOPS_2_PAT1 }}
+        run: gh pr review --approve ${{ steps.create_pr.outputs.pr_number }}


### PR DESCRIPTION
## Jira task - n/a

## Release Notes Description (public)

<!-- internal CI change, no release notes -->

## Implementation details (internal)

`Bump ACP image` PRs are now auto-approved by the devops service accounts and have auto-merge (squash) enabled, so they merge automatically once required CI checks pass. 
No human approval is required.

## Information for QA

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?