### PR TITLE
ci: fix Bump ACP auto-approve and auto-merge

### DIFF
--- a/.github/workflows/update-acp-image.yml
+++ b/.github/workflows/update-acp-image.yml
@@ -31,7 +31,6 @@ jobs:
           new_branch: bump-acp-image-${{ steps.date.outputs.date }}
 
       - name: Create PR
-        id: create_pr
         uses: devops-infra/action-pull-request@v0.5.3
         with:
           source_branch: bump-acp-image-${{ steps.date.outputs.date }}
@@ -42,13 +41,11 @@ jobs:
           allow_no_diff: false
 
       - name: Auto-approve PR
-        if: steps.create_pr.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ secrets.GH_SERVICE_ACCOUNT_DEVOPS_2_PAT1 }}
-        run: gh pr review --approve ${{ steps.create_pr.outputs.pr_number }}
+        run: gh pr review --approve bump-acp-image-${{ steps.date.outputs.date }}
 
       - name: Enable auto-merge
-        if: steps.create_pr.outputs.pr_number != ''
         env:
           GH_TOKEN: ${{ secrets.GH_SERVICE_ACCOUNT_DEVOPS_2_PAT1 }}
-        run: gh pr merge --auto --squash ${{ steps.create_pr.outputs.pr_number }}
+        run: gh pr merge --auto --squash bump-acp-image-${{ steps.date.outputs.date }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ikawalec @plandzwojczak-cloudentity @mbilski @piotrek-janus @holowinski @bwereszczak @jdabrowski
+* @ikawalec @plandzwojczak-sa @mbilski @piotrek-janus @holowinski @bwereszczak @jdabrowski

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ikawalec @plandzwojczak-cloudentity @mbilski @piotrek-janus @holowinski
+* @ikawalec @plandzwojczak-cloudentity @mbilski @piotrek-janus @holowinski @bwereszczak @jdabrowski


### PR DESCRIPTION
## Jira task - n/a

## Release Notes Description (public)

## Implementation details (internal)

- **CI fix**: `devops-infra/action-pull-request@v0.5.3` does not expose a `pr_number` output, so the `steps.create_pr.outputs.pr_number != ''` guard introduced in #584 was always false and both Auto-approve PR and Enable auto-merge steps were silently skipped (e.g. PR #587). Pass the head branch name to `gh pr review/merge` instead — both accept `<number> | <url> | <branch>`.
- **CODEOWNERS**: add `@bwereszczak` and `@jdabrowski`; rename `@plandzwojczak-cloudentity` → `@plandzwojczak-sa` (post-rebrand handle).

## Information for QA

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?