### PR TITLE
chore: disable docker workflow, scope CODEOWNERS, auto-merge dependabot

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yaml
+++ b/.github/workflows/dependabot-auto-approve.yaml
@@ -19,3 +19,8 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GH_SERVICE_ACCOUNT_DEVOPS_2_PAT1}}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,10 +1,7 @@
 name: docker
 
 on:
-  push:
-    branches:
-      - master
-      - 'release/*'
+  workflow_dispatch:
 
 jobs:
   docker:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @ikawalec @plandzwojczak-sa @mbilski @piotrek-janus @holowinski @bwereszczak @jdabrowski
+/.env-local @ikawalec

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
 * @ikawalec @plandzwojczak-sa @mbilski @piotrek-janus @holowinski @bwereszczak @jdabrowski
 /.env-local @ikawalec
+**/package*.json @ikawalec
+/go.* @ikawalec

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,3 @@
-* @ikawalec @plandzwojczak-sa @mbilski @piotrek-janus @holowinski @bwereszczak @jdabrowski
 /.env-local @ikawalec
 **/package*.json @ikawalec
 /go.* @ikawalec


### PR DESCRIPTION
## Jira task - n/a

## Release Notes Description (public)

## Implementation details (internal)

Stop spamming the whole team on auto-bump PRs (dependabot + ACP). Target flow after this PR: bot opens PR → auto-approve → CI green → auto-merge squash. Only `@ikawalec` gets review-request notifications along the way.

- Disable `docker` workflow auto-trigger
- Drop catch-all CODEOWNERS rule; scope `.env-local`, `package*.json`, `go.*` to `@ikawalec`.
- Enable auto-merge for dependabot PRs.

## Information for QA

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?