### PR TITLE
chore: extend CODEOWNERS to cover lock files and Dockerfiles

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
 /.env-local @ikawalec
 **/package*.json @ikawalec
+**/*.lock @ikawalec
 /go.* @ikawalec
+**/Dockerfile @ikawalec


### PR DESCRIPTION
## Jira task - https://secureauth.atlassian.net/browse/AUT-13640

## Release Notes Description (public)

## Implementation details (internal)

Follow-up to #591. Extends path-specific CODEOWNERS to two ecosystems still missed: `**/*.lock` (catches `tests/yarn.lock`) and `**/Dockerfile` (10 non-vendored Dockerfiles, dependabot base-image bumps). Same `@ikawalec`-only scope as the other auto-bump paths.

## Information for QA

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?