### PR TITLE
DEVOPS-8397: chore(security): pin external GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yaml
+++ b/.github/workflows/dependabot-auto-approve.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.1.1
+        uses: dependabot/fetch-metadata@a3e5f86ae9f2f49b441498973ddec20035d326b8 # v1.1.1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR - dependabot

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,16 +29,16 @@ jobs:
     name: Build and push docker ${{ matrix.images.suffix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -47,7 +47,7 @@ jobs:
           echo "VERSION=$(./scripts/version.sh)" >> $GITHUB_ENV
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           push: true
           tags: cloudentity/openbanking-quickstart-${{ matrix.images.suffix }}:${{ env.VERSION }}

--- a/.github/workflows/update-acp-image.yml
+++ b/.github/workflows/update-acp-image.yml
@@ -13,7 +13,7 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ref: master
           fetch-depth: 0
@@ -22,7 +22,7 @@ jobs:
         run: ./scripts/override_env.sh ACP_VERSION ${{ github.event.client_payload.acp-version }} 
 
       - name: Commit changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
         with:
           author_name: Github automation
           author_email: mail@example.com
@@ -31,7 +31,7 @@ jobs:
           new_branch: bump-acp-image-${{ steps.date.outputs.date }}
 
       - name: Create PR
-        uses: devops-infra/action-pull-request@v0.5.3
+        uses: devops-infra/action-pull-request@d2b6e10c00db8cf882070717497bfcebe0414e18 # v0.5.3
         with:
           source_branch: bump-acp-image-${{ steps.date.outputs.date }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Pin every **external** third-party GitHub Action to a full-length commit SHA with a
trailing version comment, mitigating the mutable-tag supply-chain attack class
(e.g. the `tj-actions/changed-files` compromise). A moved tag can no longer swap
code into our CI — the SHA is immutable, and the comment preserves the original
version for readability and Renovate updates.

Internal `SecureAuthCorp/*` references are intentionally left on floating tags
(`@main` / `@v1`) — same-org sources where floating is by design and the
external-maintainer threat does not apply.

No functional change: every SHA resolves to the exact commit the existing tag
currently points to.

This mirrors the org `github-actions` repo change (PR #90).

JIRA: https://secureauth.atlassian.net/browse/DEVOPS-8397
